### PR TITLE
feat: rename project to jota-transcriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 bin/
 models/
 *.wav
+venv/
 
 # SSL/TLS Certificates and Keys
 *.crt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,20 +36,20 @@ Tests require a model file at `third_party/whisper.cpp/models/ggml-base.bin`.
 ## Running the Server
 
 ```bash
-# Minimal (no auth, no TLS)
-./build/transcription_server --model /path/to/ggml-base.bin
-
-# With auth and TLS
-./build/transcription_server \
-  --model /path/to/ggml-base.bin \
-  --bind 0.0.0.0 --port 9001 \
-  --auth-token YOUR_TOKEN \
-  --cert server.crt --key server.key \
-  --max-connections 8 --max-connections-per-ip 2
+# Run Server:
+./build/jota-transcriber --model /path/to/ggml-base.bin
+# Or with params:
+./build/jota-transcriber \
+    --model /path/to/ggml-base.bin \
+    --bind 0.0.0.0 --port 8003 \
+    --whisper-beam-size 5 --whisper-threads 4 \
+    --auth-token YOUR_TOKEN \
+    --cert server.crt --key server.key \
+    --max-connections 8 --max-connections-per-ip 2
+```
 
 # Generate self-signed certs
 ./generate_certs.sh
-```
 
 ## Docker
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(transcription_service)
+project(jota-transcriber)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -50,9 +50,9 @@ if(BUILD_SERVER)
         message(STATUS "Mosquitto C++ found: ${MOSQUITTO_INCLUDE_DIR}")
     else()
         message(FATAL_ERROR "Mosquitto C++ not found. Install libmosquittopp-dev.")
-    endif()
+    endif(BUILD_SERVER)
 
-    add_executable(transcription_server
+    add_executable(jota-transcriber
         src/server.cpp
         src/server/StreamingSession.cpp
         src/server/AuthManager.cpp
@@ -63,12 +63,14 @@ if(BUILD_SERVER)
         src/auth/AuthCache.cpp
     )
 
-    target_include_directories(transcription_server PRIVATE
-        ${CMAKE_SOURCE_DIR}/src
-        ${MOSQUITTO_INCLUDE_DIRS}
+    target_include_directories(jota-transcriber PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/json/include
+        ${Boost_INCLUDE_DIRS}
     )
 
-    target_link_libraries(transcription_server PRIVATE
+    target_link_libraries(jota-transcriber PRIVATE
+        whisper
         Boost::boost
         pthread
         streaming_whisper

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Copia de binarios y utilidades
-COPY --from=builder /app/build/transcription_server /app/transcription_server
+COPY --from=builder /app/build/jota-transcriber /app/jota-transcriber
 COPY --from=builder /app/generate_certs.sh /app/generate_certs.sh
 
 RUN mkdir -p /app/models && chown -R appuser:appuser /app
@@ -57,4 +57,4 @@ USER appuser
 
 EXPOSE 8003
 
-CMD ["./transcription_server"]
+CMD ["./jota-transcriber"]

--- a/README.md
+++ b/README.md
@@ -48,17 +48,21 @@ cd third_party/whisper.cpp/models
 
 ```bash
 # Minimal — no auth, no TLS
-./build/transcription_server --model third_party/whisper.cpp/models/ggml-small.bin
+./build/jota-transcriber --model third_party/whisper.cpp/models/ggml-small.bin
 
 # With static auth token and TLS
-./build/transcription_server \
+./build/jota-transcriber \
   --model /path/to/ggml-small.bin \
   --bind 0.0.0.0 --port 9001 \
   --auth-token YOUR_TOKEN \
-  --cert server.crt --key server.key
+  --cert server.crt --key server.key \
+  --max-connections 10 \
+  --max-connections-per-ip 2 \
+  --whisper-beam-size 5 \
+  --whisper-threads 4
 
 # With external auth API (validates tokens against your own backend)
-./build/transcription_server \
+./build/jota-transcriber \
   --model /path/to/ggml-small.bin \
   --auth-api-url http://auth-service:8080/validate \
   --auth-api-secret API_SECRET

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ version: '3.8'
 services:
   server:
     build: .
-    image: transcription-server:latest
-    container_name: transcription_server
+    image: jota-transcriber:latest
+    container_name: jota-transcriber
     network_mode: host
     env_file:
       - .env

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -390,8 +390,8 @@ int main(int argc, char* argv[]) {
 
         ServerConfig config = parseArgs(argc, argv);
 
-        std::cout << "Streaming Transcription Server\n";
-        std::cout << "──────────────────────────────\n";
+        std::cout << "jota-transcriber" << std::endl;
+        std::cout << "────────────────" << std::endl;
 
         bool use_ssl    = !config.cert_path.empty() && !config.key_path.empty();
         bool auth_enabled = !config.auth_api_url.empty();

--- a/src/server/ServerConfig.h
+++ b/src/server/ServerConfig.h
@@ -19,9 +19,9 @@ struct ServerConfig {
     int auth_api_timeout = 5;           // seconds
 
     // MQTT
-    std::string mqtt_url;               // empty = MQTT disabled (e.g. mqtt://localhost:1883)
-    std::string mqtt_topic       = "transcription";
-    std::string mqtt_client_id   = "transcription_server";
+    std::string mqtt_url         = "";
+    std::string mqtt_topic       = "transcription/results";
+    std::string mqtt_client_id   = "jota-transcriber";
 
     int whisper_beam_size = 1;          // beam search size (1 = greedy, fastest for streaming)
     int whisper_threads = 4;            // threads per transcription


### PR DESCRIPTION
Rename binary and project from `transcription_server` / `transcription_service` to `jota-transcriber` for consistency with the product name.

- CMakeLists.txt: project() name + add_executable() target renamed; fix include dirs to use CMAKE_CURRENT_SOURCE_DIR, add Boost and json headers, link whisper explicitly, fix endif() label
- Dockerfile: COPY and CMD updated to jota-transcriber
- docker-compose.yml: image and container_name updated
- src/server.cpp: startup banner updated
- src/server/ServerConfig.h: mqtt_client_id default + mqtt_topic default changed to transcription/results
- README.md / CLAUDE.md: binary name in usage examples updated
- .gitignore: add venv/ (Python virtualenv)