### PR TITLE
fix: correct client protocol docs and test client Ctrl+C handling

### DIFF
--- a/clients/API_GUIDE.md
+++ b/clients/API_GUIDE.md
@@ -130,13 +130,18 @@ Respuesta al mensaje `config` cuando todo es correcto.
 ```json
 {
   "type": "ready",
+  "protocol_version": 1,
   "session_id": "session-1709123456789-4821",
   "config": {
     "language": "es",
-    "sample_rate": 16000
+    "sample_rate": 16000,
+    "beam_size": 1,
+    "publish_mqtt": false
   }
 }
 ```
+
+`protocol_version` identifica la versión del protocolo WebSocket. Incrementará si se introducen cambios incompatibles. Los clientes pueden usarlo para negociar compatibilidad.
 
 ---
 

--- a/clients/README.md
+++ b/clients/README.md
@@ -68,25 +68,21 @@ ffmpeg -i video.mp4 -ar 16000 -ac 1 -sample_fmt s16 audio.wav
 
 El cliente implementa el protocolo JSON del servidor:
 
-1. **Configuración**:
+1. **Configuración** (primer mensaje obligatorio):
 ```json
 {
   "type": "config",
   "language": "es",
-  "energy_threshold": 0.02,
-  "min_silence_frames": 20
+  "token": "TU_TOKEN",
+  "publish_mqtt": false,
+  "vad_thold": 0.0
 }
 ```
+`token` solo es obligatorio si el servidor tiene auth activado. `language`, `publish_mqtt` y `vad_thold` son opcionales.
 
-2. **Audio** (chunks de 100ms):
-```json
-{
-  "type": "audio",
-  "data": "base64_encoded_float32_pcm",
-  "sample_rate": 16000,
-  "channels": 1
-}
-```
+2. **Audio** (frames WebSocket binarios, NO JSON):
+
+Los datos de audio se envían como **frames WebSocket binarios**: float32 little-endian, 16 kHz, mono. Chunks recomendados de 100–500 ms (1 600–8 000 muestras = 6 400–32 000 bytes).
 
 3. **Finalización**:
 ```json
@@ -97,10 +93,10 @@ El cliente implementa el protocolo JSON del servidor:
 
 ### Respuestas del Servidor
 
-- **Ready**: Confirmación de configuración
-- **Transcription**: Texto transcrito (parcial o final)
-- **VAD State**: Estado de detección de voz (opcional)
-- **Error**: Mensajes de error
+- **Ready**: Confirmación de configuración con `session_id` y parámetros activos
+- **Transcription**: Texto transcrito acumulativo (`is_final: false` parcial, `is_final: true` tras `end`)
+- **Warning**: Aviso no fatal, ej. `"code": "buffer_full"` cuando el buffer supera 20 s
+- **Error**: Error de sesión con `code` (ver `clients/API_GUIDE.md` para lista completa)
 
 ## Cliente Web (Próximamente)
 

--- a/clients/test_client.py
+++ b/clients/test_client.py
@@ -50,6 +50,7 @@ class TranscriptionClient:
         self.server_url = server_url
         self.ws = None
         self.running = False
+        self.received_final = False
     
     async def connect(self):
         """Conectar al servidor WebSocket"""
@@ -236,6 +237,8 @@ class TranscriptionClient:
                 text = msg.get("text", "")
                 marker = "🔴" if is_final else "⚪"
                 print(f"{marker} {text}")
+                if is_final:
+                    self.received_final = True
             
             elif msg_type == "warning":
                 print(f"⚠️  Servidor: [{msg.get('code')}] {msg.get('message')}")
@@ -286,17 +289,25 @@ async def main():
         elif args.generate:
             await client.send_generated_audio(args.generate, args.duration, args.freq)
             
-        await client.send_end()
-        
-        # Esperar últimos mensajes
-        print("⏳ Esperando respuestas finales (3s)...")
-        t_end = asyncio.get_event_loop().time() + 3.0
-        while asyncio.get_event_loop().time() < t_end:
-            await client.process_pending_messages()
-            await asyncio.sleep(0.1)
-            
     except KeyboardInterrupt:
-        print("\n👋 Interrumpido por usuario")
+        print("\n👋 Grabación interrumpida por usuario. Obteniendo último bloque de texto...")
+        client.running = False
+
+    try:
+        # Enviar fin y esperar respuesta final si todo salió bien o si se interrumpió la grabación
+        if client.ws and not client.ws.closed:
+            await client.send_end()
+            
+            print("⏳ Esperando transcripción final...")
+            # Poner un timeout lógico en caso de que el servidor no responda is_final=true
+            t_end = asyncio.get_event_loop().time() + 10.0
+            while not client.received_final and asyncio.get_event_loop().time() < t_end:
+                await client.process_pending_messages()
+                await asyncio.sleep(0.05)
+                
+            if not client.received_final:
+                print("⚠️  Tiempo de espera agotado sin recibir is_final=true")
+            
     except Exception as e:
         print(f"❌ Error fatal: {e}")
     finally:


### PR DESCRIPTION
clients/README.md:
- Config message now shows real fields: token, publish_mqtt, vad_thold (previously showed defunct energy_threshold / min_silence_frames).
- Audio section corrected: audio is binary WebSocket frames (float32 LE, 16 kHz mono), not JSON/base64. Documents recommended chunk sizes.
- Server responses section updated with correct message types (warning replaces VAD State) and accurate descriptions.

clients/API_GUIDE.md:
- ready message example now includes protocol_version, beam_size, and publish_mqtt fields that the server actually sends.
- Add paragraph explaining protocol_version semantics.

clients/test_client.py:
- Track received_final flag to detect when server has sent is_final=true.
- On KeyboardInterrupt: gracefully send end message instead of discarding in-progress audio, wait up to 10 s for final transcription.
- Timeout warning if server doesn't respond with is_final=true in time.