### PR TITLE
feat: protocol_version en ready + fallback raw_transcription_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 - `--auth-token` flag for static local token authentication — constant-time comparison, no external API required. Also available as `AUTH_TOKEN` env var.
+- `protocol_version: 1` field in the `ready` message — clients can use this to detect protocol breaking changes in future releases.
 
 ### Fixed
 - `buffer_overflowed_` flag now resets deterministically in `flushLoop` when inference drains the buffer below the 20s HWM, instead of waiting for the next client audio chunk.
+
+### Docs
+- `clients/README.md`: corrected the Protocol section — config message now shows the actual fields (`token`, `publish_mqtt`, `vad_thold`) and audio is documented as binary WebSocket frames (float32 LE), not JSON/base64.
+- `clients/API_GUIDE.md`: `ready` message example now includes `beam_size`, `publish_mqtt`, and `protocol_version` fields that the server actually sends.
 
 ---
 

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -45,7 +45,7 @@ private:
         auto& out = (level >= Level::WARN) ? std::cerr : std::cout;
         out << timestamp() << " " << tag(level);
         if (!ctx.empty()) out << " [" << ctx << "]";
-        out << " " << msg << "\n";
+        out << " " << msg << std::endl;
     }
 
     static std::string timestamp() {

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -179,6 +179,7 @@ private:
     void sendReady() {
         json msg = {
             {"type", "ready"},
+            {"protocol_version", 1},
             {"session_id", session_id_},
             {"config", {
                 {"language", language_},
@@ -374,6 +375,7 @@ private:
                 configured_ = true;
                 last_transcribed_size_ = 0;
                 full_transcription_    = "";
+                raw_transcription_     = "";
                 last_audio_time_ = std::chrono::steady_clock::now();
             }
 
@@ -396,7 +398,17 @@ private:
             std::lock_guard<std::mutex> lock(state_mutex_);
             if (engine_) {
                 auto res = engine_->transcribeSlidingWindow(true); // force commit
+                // Note: no hallucination guard here — this is the last chance to capture audio
+                // that the engine still holds in its buffer.
                 full_transcription_ += res.committed_text;
+            }
+
+            // Fallback: if all flushLoop commits were hallucination-filtered (audio was erased
+            // from the engine buffer but text was discarded), full_transcription_ is empty.
+            // Use the raw accumulated text so the client receives something rather than nothing.
+            if (full_transcription_.empty() && !raw_transcription_.empty()) {
+                Log::warn("full_transcription_ empty at end-of-session — using raw fallback (all commits were hallucination-filtered)", session_id_);
+                full_transcription_ = raw_transcription_;
             }
         }
 
@@ -476,7 +488,8 @@ private:
     std::chrono::steady_clock::time_point last_audio_time_;
 
     // Sliding window logic
-    std::string full_transcription_;
+    std::string full_transcription_;     // filtered (hallucinations discarded)
+    std::string raw_transcription_;      // unfiltered fallback — used when full_ is empty at handleEnd()
 
     void flushLoop() {
         // Handles ALL inference, decoupled from the WebSocket receive loop.
@@ -531,6 +544,10 @@ private:
             bool partial_ok   = !res.partial_text.empty()   && !isHallucination(res.partial_text);
 
             if (!res.committed_text.empty()) {
+                // Always accumulate raw — audio was already erased from engine buffer,
+                // so this is the only copy left. Used as fallback in handleEnd() if all
+                // commits were hallucination-filtered and full_transcription_ ends up empty.
+                raw_transcription_ += res.committed_text;
                 if (committed_ok) {
                     full_transcription_ += res.committed_text;
                 } else {


### PR DESCRIPTION
## Summary
- \`sendReady()\` incluye \`protocol_version: 1\` para que los clientes detecten futuros cambios incompatibles de protocolo
- Añade \`raw_transcription_\` (acumulador sin filtro de alucinaciones); en \`handleEnd()\` se usa como fallback si \`full_transcription_\` queda vacía
- \`Log.h\`: \`std::endl\` en lugar de \`\"\\n\"\` para flush inmediato

## Test Plan
- [ ] Cliente recibe \`{"type":"ready","protocol_version":1,...}\`
- [ ] Con audio que genere alucinaciones, la transcripción final no es cadena vacía

🤖 Generated with [Claude Code](https://claude.com/claude-code)