### PR TITLE
perf: Docker layer cache para whisper.cpp/CUDA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,22 @@ jobs:
           name: test-results
           path: test-results.xml
 
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (with layer cache)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,39 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY . .
 
-# Compilación con soporte CUDA
-# Stubs de CUDA driver necesarios para linkar libggml-cuda.so
+# Stubs de CUDA driver necesarios para linkar libggml-cuda
 ENV LIBRARY_PATH="/usr/local/cuda/lib64/stubs:${LIBRARY_PATH}"
+
+# ── Fase A: whisper.cpp + dependencias externas ────────────────────────────
+# Esta capa solo se invalida cuando cambia third_party/ o CMakeLists.txt.
+# Configura con BUILD_SERVER=ON para que FetchContent descargue nlohmann/json
+# aquí (cmake no verifica existencia de .cpp al configurar, solo al compilar).
+# Boost y OpenSSL ya están instalados arriba — los find_package pasan sin error.
+COPY third_party/ third_party/
+COPY CMakeLists.txt .
 RUN cmake -B build \
     -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_TESTS=OFF \
     -DBUILD_SERVER=ON \
-    -DGGML_CUDA=1 \
-    -DBUILD_SHARED_LIBS=OFF && \
-    cmake --build build -j$(nproc)
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_CUDA=1
+
+# Compila whisper + ggml (incluye kernels CUDA — la parte lenta).
+RUN cmake --build build --target whisper -j$(nproc)
+
+# ── Fase B: código del servidor ────────────────────────────────────────────
+# Solo se invalida cuando cambia src/ o generate_certs.sh.
+# cmake detecta que whisper/ggml ya están compilados y los omite.
+COPY src/ src/
+COPY generate_certs.sh .
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SERVER=ON \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_CUDA=1
+RUN cmake --build build --target jota-transcriber -j$(nproc)
 
 # Runtime Stage
 FROM nvidia/cuda:12.3.1-runtime-ubuntu22.04 AS runtime

--- a/docs/superpowers/plans/2026-03-14-docker-layer-cache.md
+++ b/docs/superpowers/plans/2026-03-14-docker-layer-cache.md
@@ -1,0 +1,254 @@
+# Docker Layer Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reestructurar el Dockerfile para que whisper.cpp/CUDA solo se recompile cuando cambia el submodule, y añadir un job de CI que cachea capas Docker en GitHub Actions.
+
+**Architecture:** Dividir el builder stage en dos fases con `COPY` separados: Fase A copia `third_party/` y `CMakeLists.txt`, configura cmake y compila `--target whisper`; Fase B copia `src/` y compila `--target jota-transcriber`. Docker layer cache mantiene Fase A intacta cuando solo cambia código fuente.
+
+**Tech Stack:** Docker multi-stage builds, CMake, GitHub Actions (`docker/setup-buildx-action`, `docker/build-push-action`)
+
+---
+
+## Chunk 1: Reestructurar Dockerfile
+
+### Task 1: Dividir el builder stage en Fase A y Fase B
+
+**Files:**
+- Modify: `Dockerfile`
+
+El Dockerfile actual tiene un único `COPY . .` que invalida todo. Hay que reemplazar el builder stage entero.
+
+- [ ] **Step 1: Leer el Dockerfile actual**
+
+```bash
+cat Dockerfile
+```
+
+Confirmar que el builder stage empieza en la línea 1 y el runtime stage en la línea 31.
+
+- [ ] **Step 2: Reemplazar el builder stage**
+
+Reemplazar **todo el builder stage** (desde `# Build Stage` hasta la línea justo antes de `# Runtime Stage`, incluyendo el `FROM`, el `apt-get`, el `WORKDIR`, el `COPY . .` y el `RUN cmake`) con:
+
+```dockerfile
+# Build Stage
+FROM nvidia/cuda:12.3.1-devel-ubuntu22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Instalamos dependencias de compilación
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libboost-all-dev \
+    libssl-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Stubs de CUDA driver necesarios para linkar libggml-cuda
+ENV LIBRARY_PATH="/usr/local/cuda/lib64/stubs:${LIBRARY_PATH}"
+
+# ── Fase A: whisper.cpp + dependencias externas ────────────────────────────
+# Esta capa solo se invalida cuando cambia third_party/ o CMakeLists.txt.
+# Configura con BUILD_SERVER=ON para que FetchContent descargue nlohmann/json
+# aquí (cmake no verifica existencia de .cpp al configurar, solo al compilar).
+# Boost y OpenSSL ya están instalados arriba — los find_package pasan sin error.
+COPY third_party/ third_party/
+COPY CMakeLists.txt .
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SERVER=ON \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_CUDA=1
+
+# Compila whisper + ggml (incluye kernels CUDA — la parte lenta).
+RUN cmake --build build --target whisper -j$(nproc)
+
+# ── Fase B: código del servidor ────────────────────────────────────────────
+# Solo se invalida cuando cambia src/ o generate_certs.sh.
+# cmake detecta que whisper/ggml ya están compilados y los omite.
+COPY src/ src/
+COPY generate_certs.sh .
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SERVER=ON \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_CUDA=1
+RUN cmake --build build --target jota-transcriber -j$(nproc)
+```
+
+El runtime stage (desde `# Runtime Stage` en adelante) no se toca.
+
+- [ ] **Step 3: Verificar la estructura del Dockerfile resultante**
+
+```bash
+grep -n "FROM\|COPY\|RUN cmake\|Fase" Dockerfile
+```
+
+Salida esperada (líneas aproximadas):
+```
+1:FROM nvidia/cuda:12.3.1-devel-ubuntu22.04 AS builder
+...
+(Fase A) COPY third_party/
+(Fase A) COPY CMakeLists.txt
+(Fase A) RUN cmake -B build ...
+(Fase A) RUN cmake --build build --target whisper
+(Fase B) COPY src/
+(Fase B) COPY generate_certs.sh
+(Fase B) RUN cmake -B build ...
+(Fase B) RUN cmake --build build --target jota-transcriber
+FROM nvidia/cuda:12.3.1-runtime-ubuntu22.04 AS runtime
+COPY --from=builder ...
+COPY --from=builder ...
+```
+
+- [ ] **Step 4: Verificar que el runtime stage está intacto**
+
+```bash
+grep -A 20 "Runtime Stage" Dockerfile
+```
+
+Debe mostrar las mismas líneas que antes: `apt-get install libboost-system...`, `COPY --from=builder`, `useradd`, `EXPOSE 8003`, `CMD`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "perf: restructure Dockerfile builder into two COPY phases for layer caching"
+```
+
+---
+
+## Chunk 2: Job de Docker build en CI
+
+### Task 2: Añadir job docker-build a ci.yml
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+Añadir un segundo job al workflow que construye la imagen Docker usando BuildKit con caché de GHA. El job existente `build-and-test` no se toca.
+
+- [ ] **Step 1: Añadir el job docker-build al workflow**
+
+Al final del fichero `.github/workflows/ci.yml` (después del job `build-and-test`), añadir:
+
+```yaml
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (with layer cache)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+La clave `docker-build:` debe estar al mismo nivel de indentación que `build-and-test:` (sin espacios antes, directamente bajo `jobs:`).
+
+- [ ] **Step 2: Verificar YAML válido**
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"
+```
+
+Salida esperada: `YAML OK`
+
+- [ ] **Step 3: Verificar que el job tiene la estructura correcta**
+
+```bash
+grep -n "jobs:\|build-and-test:\|docker-build:\|setup-buildx\|build-push-action\|cache-from\|cache-to" .github/workflows/ci.yml
+```
+
+Debe mostrar ambos jobs y las claves de caché del nuevo job.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add docker-build job with GHA layer cache"
+```
+
+---
+
+## Chunk 3: Verificación
+
+### Task 3: Verificar que el build funciona localmente (sin GPU)
+
+**Nota:** Si no hay GPU disponible en el entorno de verificación, el build con `-DGGML_CUDA=1` fallará en los kernels CUDA. En ese caso, verificar la estructura del Dockerfile y la sintaxis de ci.yml es suficiente — el build real se valida en el entorno con GPU del usuario.
+
+- [ ] **Step 1: Verificar que no quedan referencias al COPY . . problemático**
+
+```bash
+grep -n "COPY \. \." Dockerfile
+```
+
+Salida esperada: sin output (no debe haber `COPY . .`).
+
+- [ ] **Step 2: Comprobar que los dos COPY de Fase A y Fase B están en orden correcto**
+
+```bash
+grep -n "^COPY" Dockerfile
+```
+
+Salida esperada (en este orden):
+```
+XX:COPY third_party/ third_party/
+XX:COPY CMakeLists.txt .
+XX:COPY src/ src/
+XX:COPY generate_certs.sh .
+```
+
+Y en el runtime stage:
+```
+XX:COPY --from=builder /app/build/jota-transcriber /app/jota-transcriber
+XX:COPY --from=builder /app/generate_certs.sh /app/generate_certs.sh
+```
+
+- [ ] **Step 3: Verificar ci.yml tiene los dos jobs**
+
+```bash
+grep "^\s*[a-z-]*:$" .github/workflows/ci.yml | grep -v "steps:\|with:\|on:"
+```
+
+Debe mostrar `build-and-test:` y `docker-build:`.
+
+- [ ] **Step 4: Intentar docker build sin GPU (opcional, si hay Docker disponible)**
+
+Prerequisito: asegurarse de que los submodules están inicializados:
+```bash
+git submodule update --init --recursive
+```
+
+Luego lanzar el build:
+```bash
+DOCKER_BUILDKIT=1 docker build --no-cache \
+  -t jota-transcriber-test \
+  --target builder \
+  . 2>&1 | tail -20
+```
+
+Si no hay GPU, fallará en el paso `cmake --build ... --target whisper` con error de CUDA — eso es esperado. Lo importante es que Fase A (configure + FetchContent descarga nlohmann/json) pase sin errores antes del paso de compilación.
+
+- [ ] **Step 5: Commit del plan (si no está ya commiteado)**
+
+```bash
+git add docs/superpowers/plans/2026-03-14-docker-layer-cache.md
+git commit -m "docs: add Docker layer cache implementation plan"
+```

--- a/docs/superpowers/specs/2026-03-14-docker-layer-cache-design.md
+++ b/docs/superpowers/specs/2026-03-14-docker-layer-cache-design.md
@@ -1,0 +1,88 @@
+# Docker Layer Cache para whisper.cpp/CUDA — Design
+
+## Problema
+
+El `Dockerfile` actual hace un `COPY . .` antes de compilar, lo que invalida todas las capas
+Docker cada vez que cambia cualquier archivo (incluyendo `src/`). Esto fuerza recompilar
+whisper.cpp y los kernels CUDA completos en cada build, aunque no hayan cambiado.
+
+## Objetivo
+
+Conseguir que `docker-compose build` (y un eventual job de CI) solo recompile el código de
+`src/` cuando no ha cambiado el submodule de whisper.cpp, eliminando el coste de compilación
+CUDA/whisper en el flujo habitual de desarrollo.
+
+## Solución: Separación de capas en el Dockerfile
+
+Dividir el builder stage en dos fases con `COPY` separados:
+
+### Fase A — whisper.cpp (cacheada, lenta, rara)
+
+```dockerfile
+COPY third_party/ third_party/
+COPY CMakeLists.txt .
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SERVER=OFF \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_CUDA=1
+RUN cmake --build build --target whisper -j$(nproc)
+```
+
+Esta capa **solo se invalida** cuando cambia `third_party/` (el submodule de whisper.cpp)
+o `CMakeLists.txt`. Ambos casos son poco frecuentes.
+
+### Fase B — código del servidor (rápida, frecuente)
+
+```dockerfile
+COPY src/ src/
+COPY generate_certs.sh .
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SERVER=ON \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_CUDA=1
+RUN cmake --build build --target jota-transcriber -j$(nproc)
+```
+
+cmake reconfigura añadiendo los targets del servidor sin tocar los artefactos de whisper.cpp
+ya compilados. Solo se compilan los archivos de `src/`.
+
+### Runtime stage
+
+Sin cambios respecto al actual.
+
+## CI: job de Docker build con caché de capas
+
+Añadir un job `docker-build` al workflow de CI (`.github/workflows/ci.yml`) que:
+
+1. Use `docker/setup-buildx-action` (habilita BuildKit)
+2. Use `docker/build-push-action` con:
+   - `push: false` (solo build, no push)
+   - `cache-from: type=gha` — lee capas cacheadas de GitHub Actions cache
+   - `cache-to: type=gha,mode=max` — escribe todas las capas (incluyendo intermedias)
+3. Se ejecute en `push` a `main` y en pull requests
+
+Con esto, la capa de whisper.cpp compilada queda persistida en el cache de GHA (~5 GB
+disponibles gratis) y los runs siguientes la reutilizan directamente.
+
+## Flujo resultante
+
+| Escenario | Qué se recompila | Tiempo esperado |
+|-----------|-----------------|-----------------|
+| Cambia `src/` | Solo código del servidor | Rápido (segundos/minuto) |
+| Cambia `CMakeLists.txt` | whisper.cpp + servidor | Lento (igual que ahora) |
+| Cambia submodule whisper.cpp | whisper.cpp + servidor | Lento (igual que ahora) |
+
+## Archivos modificados
+
+- `Dockerfile` — reestructurar el builder stage
+- `.github/workflows/ci.yml` — añadir job `docker-build`
+
+## Archivos no modificados
+
+- `docker-compose.yml` — sin cambios
+- `CMakeLists.txt` — sin cambios
+- Runtime stage del Dockerfile — sin cambios

--- a/docs/superpowers/specs/2026-03-14-docker-layer-cache-design.md
+++ b/docs/superpowers/specs/2026-03-14-docker-layer-cache-design.md
@@ -16,39 +16,52 @@ CUDA/whisper en el flujo habitual de desarrollo.
 
 Dividir el builder stage en dos fases con `COPY` separados:
 
-### Fase A — whisper.cpp (cacheada, lenta, rara)
+### Fase A — whisper.cpp + dependencias externas (cacheada, lenta, rara)
 
 ```dockerfile
 COPY third_party/ third_party/
 COPY CMakeLists.txt .
-RUN cmake -B build \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SERVER=OFF \
-    -DBUILD_TESTS=OFF \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DGGML_CUDA=1
-RUN cmake --build build --target whisper -j$(nproc)
-```
-
-Esta capa **solo se invalida** cuando cambia `third_party/` (el submodule de whisper.cpp)
-o `CMakeLists.txt`. Ambos casos son poco frecuentes.
-
-### Fase B — código del servidor (rápida, frecuente)
-
-```dockerfile
-COPY src/ src/
-COPY generate_certs.sh .
+# Configura con BUILD_SERVER=ON para que FetchContent descargue nlohmann/json ahora.
+# cmake no verifica existencia de .cpp al configurar (solo al compilar), así que
+# funciona aunque src/ aún no esté copiado.
+# Boost y OpenSSL ya están instalados por el apt-get anterior — los find_package pasan.
+# Esta capa queda cacheada con nlohmann/json ya descargado.
 RUN cmake -B build \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SERVER=ON \
     -DBUILD_TESTS=OFF \
     -DBUILD_SHARED_LIBS=OFF \
     -DGGML_CUDA=1
+# Compila solo la librería whisper (y ggml) — los kernels CUDA pesados.
+RUN cmake --build build --target whisper -j$(nproc)
+```
+
+Esta capa **solo se invalida** cuando cambia `third_party/` (el submodule de whisper.cpp)
+o `CMakeLists.txt`. Ambos casos son poco frecuentes. `nlohmann/json` también queda
+pre-descargado en esta capa, evitando una llamada de red en Fase B.
+
+### Fase B — código del servidor (rápida, frecuente)
+
+```dockerfile
+COPY src/ src/
+COPY generate_certs.sh .
+# Reconfigura: cmake detecta que la configuración no ha cambiado y no recompila
+# los objetos de whisper ya existentes en el layer anterior.
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SERVER=ON \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_CUDA=1
+# Compila StreamingWhisperEngine.cpp (src/whisper/) y todos los archivos de src/server/,
+# src/auth/, src/log/, src/utils/ y el ejecutable jota-transcriber.
+# whisper y ggml ya están compilados — cmake los omite.
 RUN cmake --build build --target jota-transcriber -j$(nproc)
 ```
 
-cmake reconfigura añadiendo los targets del servidor sin tocar los artefactos de whisper.cpp
-ya compilados. Solo se compilan los archivos de `src/`.
+cmake detecta que los objetos de `whisper` y `ggml` están al día y no los recompila.
+Lo que se compila en Fase B: `streaming_whisper` (wrapper en `src/whisper/`) y todo
+el código del servidor en `src/`.
 
 ### Runtime stage
 
@@ -66,13 +79,15 @@ Añadir un job `docker-build` al workflow de CI (`.github/workflows/ci.yml`) que
 3. Se ejecute en `push` a `main` y en pull requests
 
 Con esto, la capa de whisper.cpp compilada queda persistida en el cache de GHA (~5 GB
-disponibles gratis) y los runs siguientes la reutilizan directamente.
+disponibles gratis) y los runs siguientes la reutilizan directamente. Nota: los artefactos
+CUDA de whisper pueden ser voluminosos; si se supera el límite de caché de GHA, la capa
+se evicta y se recompila en el siguiente run (comportamiento degradado, no rotura).
 
 ## Flujo resultante
 
 | Escenario | Qué se recompila | Tiempo esperado |
 |-----------|-----------------|-----------------|
-| Cambia `src/` | Solo código del servidor | Rápido (segundos/minuto) |
+| Cambia `src/` (incluyendo headers) | `streaming_whisper` + código del servidor | Rápido (segundos/minuto) |
 | Cambia `CMakeLists.txt` | whisper.cpp + servidor | Lento (igual que ahora) |
 | Cambia submodule whisper.cpp | whisper.cpp + servidor | Lento (igual que ahora) |
 


### PR DESCRIPTION
## Summary

- Reestructurado el builder stage del `Dockerfile` en dos fases `COPY` separadas:
  - **Fase A** (`third_party/` + `CMakeLists.txt`): compila whisper + ggml/CUDA — solo se invalida cuando cambia el submodule o el CMakeLists
  - **Fase B** (`src/`): compila `streaming_whisper` + `jota-transcriber` — se invalida solo cuando cambia el código fuente
- Añadido job `docker-build` en CI que usa `docker/build-push-action` con `cache-from/cache-to: type=gha` para persistir capas Docker entre runs de GitHub Actions

## Resultado

| Escenario | Antes | Después |
|-----------|-------|---------|
| Cambia `src/` | Recompila todo (CUDA + whisper + server) | Solo recompila server |
| Cambia `third_party/` | Recompila todo | Recompila todo (esperado) |

## Test plan

- [ ] `docker-compose build` con cambio en `src/` → Fase A cacheada, solo Fase B recompila
- [ ] CI job `docker-build` pasa en el primer run (build completo) y en el segundo (cache hit en Fase A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)