### PR TITLE
fix: server quick wins — model arg, auth nullptr, verbose_json thread-safety, text/plain trim

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -257,7 +257,7 @@ ServerConfig parseArgs(int argc, char* argv[]) {
         } else if (arg == "--thread-safe") {
             // accepted for backwards compatibility
         } else if (arg.rfind("--", 0) != 0 &&
-                   config.model_path == "third_party/whisper.cpp/models/ggml-base.bin") {
+                   config.model_path == ServerConfig{}.model_path) {
             config.model_path = arg;
         
         } else if (arg == "--max-upload-bytes" && i + 1 < argc) {

--- a/src/server/handlers/HandleTranscribe.cpp
+++ b/src/server/handlers/HandleTranscribe.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <iomanip>
 #include <ctime>
+#include <random>
 
 using json = nlohmann::json;
 namespace http = boost::beast::http;
@@ -303,14 +304,18 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
         });
     }
 
-    // Generate id and timestamp
+    // Generate id (thread-safe via thread_local RNG)
+    static thread_local std::mt19937_64 rng(std::random_device{}());
     std::stringstream ss;
-    ss << "transcribe-" << std::hex << std::setw(16) << std::setfill('0') << rand();
+    ss << "transcribe-" << std::hex << std::setw(16) << std::setfill('0') << rng();
     std::string id = ss.str();
 
+    // Format timestamp (thread-safe via gmtime_r)
     std::time_t now = std::time(nullptr);
+    struct tm tm_buf{};
+    gmtime_r(&now, &tm_buf);
     char buf[64];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&now));
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
 
 
     json vj = {

--- a/src/server/handlers/HandleTranscribe.cpp
+++ b/src/server/handlers/HandleTranscribe.cpp
@@ -49,6 +49,13 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
     const unsigned ver = req.version();
 
     // ── 1. Auth ───────────────────────────────────────────────────────────────
+    const bool auth_configured = !config.auth_token.empty() || !config.auth_api_url.empty();
+    if (!auth && auth_configured) {
+        Log::error("HandleTranscribe: auth_manager is null but auth is configured — rejecting");
+        send(makeError(http::status::internal_server_error,
+                       "Internal server error", "server_error", ver));
+        return;
+    }
     if (auth && auth->isAuthEnabled()) {
         std::string auth_header = std::string(req[http::field::authorization]);
         std::string token;

--- a/src/server/handlers/HandleTranscribe.cpp
+++ b/src/server/handlers/HandleTranscribe.cpp
@@ -273,7 +273,9 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
 
     if (response_format == "text") {
         auto first = text.find_first_not_of(" \t\r\n");
-        std::string trimmed = (first == std::string::npos) ? "" : text.substr(first);
+        auto last  = text.find_last_not_of(" \t\r\n");
+        std::string trimmed = (first == std::string::npos) ? ""
+                            : text.substr(first, last - first + 1);
         http::response<http::string_body> res;
         res.version(ver);
         res.result(http::status::ok);

--- a/src/whisper/ModelCache.h
+++ b/src/whisper/ModelCache.h
@@ -4,8 +4,8 @@
 #include <thread>
 #include <atomic>
 #include <functional>
-#include <iostream>
 #include <whisper.h>
+#include "log/Log.h"
 
 /**
  * @brief Singleton cache for the whisper model context.
@@ -61,14 +61,14 @@ public:
 
         // Different model requested while one is loaded — unload first
         if (ctx_) {
-            std::cout << "[ModelCache] Unloading previous model: " << loaded_path_ << std::endl;
+            Log::info("ModelCache: unloading previous model: " + loaded_path_);
             whisper_free(ctx_);
             ctx_ = nullptr;
             loaded_path_.clear();
         }
 
         // Load the model
-        std::cout << "[ModelCache] Loading model: " << model_path << std::endl;
+        Log::info("ModelCache: loading model: " + model_path);
         whisper_context_params cparams = whisper_context_default_params();
         cparams.use_gpu    = use_gpu;
         cparams.flash_attn = true;
@@ -80,7 +80,7 @@ public:
 
         loaded_path_ = model_path;
         ref_count_ = 1;
-        std::cout << "[ModelCache] Model loaded successfully" << std::endl;
+        Log::info("ModelCache: model loaded successfully");
         return ctx_;
     }
 
@@ -154,7 +154,7 @@ private:
 
     void unloadLocked() {
         if (ctx_) {
-            std::cout << "[ModelCache] Unloading model: " << loaded_path_ << std::endl;
+            Log::info("ModelCache: unloading model: " + loaded_path_);
             whisper_free(ctx_);
             ctx_ = nullptr;
             loaded_path_.clear();

--- a/tests/unit/test_handle_transcribe.cpp
+++ b/tests/unit/test_handle_transcribe.cpp
@@ -227,6 +227,11 @@ TEST_F(HandleTranscribeTest, ResponseFormatTextReturnsPlainText) {
     // No leading whitespace
     EXPECT_TRUE(b.empty() || b.front() != ' ')
         << "Expected trimmed text, got leading space";
+    // No trailing whitespace
+    EXPECT_TRUE(b.empty() || b.back() != ' ')
+        << "Expected no trailing space, got: '" << b << "'";
+    EXPECT_TRUE(b.empty() || (b.back() != '\n' && b.back() != '\r'))
+        << "Expected no trailing newline, got: '" << b << "'";
 }
 
 TEST_F(HandleTranscribeTest, ResponseFormatVerboseJsonHasSegmentsKey) {

--- a/tests/unit/test_handle_transcribe.cpp
+++ b/tests/unit/test_handle_transcribe.cpp
@@ -444,3 +444,42 @@ TEST_F(HandleTranscribeTest, TemperatureValidInRangeReturns200) {
     EXPECT_EQ(res.result(), http::status::ok);
     EXPECT_NE(res.body().find("\"text\""), std::string::npos);
 }
+
+TEST_F(HandleTranscribeTest, Returns500WhenAuthManagerIsNullButAuthConfigured) {
+    config.auth_token = "expected-token";  // auth debería estar activa
+
+    auto audio = makeSilentWav(0.5f);
+    auto body  = makeMultipartBody("bnd", audio);
+
+    http::request<http::string_body> req{http::verb::post, "/v1/audio/transcriptions", 11};
+    req.set(http::field::content_type, "multipart/form-data; boundary=bnd");
+    req.body() = body;
+    req.prepare_payload();
+
+    http::response<http::string_body> res;
+    HandleTranscribe::handle(req,
+        [&](http::response<http::string_body> r) { res = std::move(r); },
+        config,
+        nullptr);  // null auth_manager pese a tener config de auth
+
+    EXPECT_EQ(res.result(), http::status::internal_server_error);
+}
+
+TEST_F(HandleTranscribeTest, NullAuthManagerWithNoAuthConfigIsAccepted) {
+    // config.auth_token está vacío por defecto → auth desactivada → null es válido
+    auto audio = makeSilentWav(0.5f);
+    auto body  = makeMultipartBody("bnd", audio, "en");
+
+    http::request<http::string_body> req{http::verb::post, "/v1/audio/transcriptions", 11};
+    req.set(http::field::content_type, "multipart/form-data; boundary=bnd");
+    req.body() = body;
+    req.prepare_payload();
+
+    http::response<http::string_body> res;
+    HandleTranscribe::handle(req,
+        [&](http::response<http::string_body> r) { res = std::move(r); },
+        config,
+        nullptr);  // null auth + sin config → OK
+
+    EXPECT_EQ(res.result(), http::status::ok);
+}


### PR DESCRIPTION
## Summary

- **C6** `server.cpp:260` — positional model argument was silently ignored: comparison against hardcoded `ggml-base.bin` but default is `ggml-small.bin`. Now uses `ServerConfig{}.model_path`
- **D1** `ModelCache.h` — replaces 4 unsynchronized `std::cout` with `Log::info()` for thread-safe output
- **I5** `HandleTranscribe.cpp:52` — returns 500 if `auth_manager` is null but auth is configured in `ServerConfig`, instead of silently accepting the request
- **I7** `HandleTranscribe.cpp:298` — `rand()` + `std::gmtime` replaced by `thread_local mt19937_64` + `gmtime_r` (thread-safe) in `verbose_json` id/timestamp generation
- **M4** `HandleTranscribe.cpp:268` — `text/plain` response now trims both leading and trailing whitespace (previously only leading)

## Test plan
- [x] `./run_tests.sh` → all tests pass, 0 failures
- [x] `./build/jota-transcriber /path/to/model` (positional arg) → model path shows correctly in startup logs
- Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)