### PR TITLE
fix: ModelCache stability — RAII guard, cancelable timer, destructor safety

### DIFF
--- a/src/server/handlers/HandleTranscribe.cpp
+++ b/src/server/handlers/HandleTranscribe.cpp
@@ -9,6 +9,7 @@
 #include <whisper.h>
 #include <nlohmann/json.hpp>
 #include <boost/beast/version.hpp>
+#include <optional>
 #include <unordered_set>
 #include <sstream>
 #include <iomanip>
@@ -145,15 +146,16 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
     }
 
     // ── 6. Acquire model context ──────────────────────────────────────────────
-    whisper_context* ctx = nullptr;
+    std::optional<ModelCache::Guard> model_guard;
     try {
-        ctx = ModelCache::instance().acquire(config.model_path);
+        model_guard.emplace(config.model_path);
     } catch (const std::exception& e) {
         Log::error(std::string("HandleTranscribe: model load failed: ") + e.what());
         send(makeError(http::status::internal_server_error,
                        "Failed to load model", "server_error", ver));
         return;
     }
+    whisper_context* ctx = model_guard->ctx();
 
     // ── 7. Transcribe ─────────────────────────────────────────────────────────
     // Declared before guard so they're accessible when formatting the response below.
@@ -183,7 +185,6 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
 
         whisper_state* state = whisper_init_state(ctx);
         if (!state) {
-            ModelCache::instance().release();
             send(makeError(http::status::internal_server_error,
                            "Failed to initialize whisper state", "server_error", ver));
             return;
@@ -228,7 +229,6 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
                 float val = std::stof(t);
                 if (val < 0.0f || val > 1.0f) {
                     whisper_free_state(state);
-                    ModelCache::instance().release();
                     send(makeError(http::status::bad_request,
                                    "temperature must be between 0.0 and 1.0",
                                    "invalid_request_error", ver));
@@ -244,7 +244,6 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
 
         if (rc != 0) {
             whisper_free_state(state);
-            ModelCache::instance().release();
             Log::error("HandleTranscribe: whisper returned " + std::to_string(rc));
             send(makeError(http::status::internal_server_error,
                            "Whisper inference failed", "server_error", ver));
@@ -267,7 +266,6 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
         whisper_free_state(state);
     }
 
-    ModelCache::instance().release();
     Log::info("HandleTranscribe: transcribed " + std::to_string(pcm.size()) +
             " samples → " + std::to_string(text.size()) + " chars"
                 + " format=" + response_format);

--- a/src/whisper/ModelCache.h
+++ b/src/whisper/ModelCache.h
@@ -1,8 +1,9 @@
 #pragma once
 #include <string>
 #include <mutex>
-#include <thread>
-#include <atomic>
+#include <condition_variable>
+#include <future>
+#include <chrono>
 #include <functional>
 #include <whisper.h>
 #include "log/Log.h"
@@ -160,7 +161,15 @@ public:
     ModelCache& operator=(const ModelCache&) = delete;
 
     ~ModelCache() {
-        cancelUnloadLocked();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            shutdown_ = true;
+            unload_pending_ = false;
+        }
+        cv_.notify_all();
+        if (unload_future_.valid())
+            unload_future_.get();
+        // ctx_ is safe to access now: timer task has exited
         if (ctx_) {
             whisper_free(ctx_);
             ctx_ = nullptr;
@@ -181,8 +190,9 @@ private:
     }
 
     void cancelUnloadLocked() {
-        if (unload_pending_.exchange(false)) {
-            // The timer thread will check unload_pending_ and skip the unload
+        if (unload_pending_) {
+            unload_pending_ = false;
+            cv_.notify_all();
         }
     }
 
@@ -190,22 +200,24 @@ private:
         unload_pending_ = true;
         int ttl = ttl_seconds_;
 
-        // Detach a lightweight timer thread
-        std::thread([this, ttl]() {
-            std::this_thread::sleep_for(std::chrono::seconds(ttl));
-
-            std::lock_guard<std::mutex> lock(mutex_);
-            if (unload_pending_ && ref_count_ == 0) {
+        unload_future_ = std::async(std::launch::async, [this, ttl]() {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait_for(lock, std::chrono::seconds(ttl),
+                         [this]() { return !unload_pending_ || shutdown_; });
+            if (unload_pending_ && !shutdown_) {
                 unloadLocked();
                 unload_pending_ = false;
             }
-        }).detach();
+        });
     }
 
     mutable std::mutex mutex_;
+    std::condition_variable cv_;
     whisper_context* ctx_ = nullptr;
     std::string loaded_path_;
     int ref_count_ = 0;
     int ttl_seconds_ = 300; // default 5 minutes
-    std::atomic<bool> unload_pending_{false};
+    bool unload_pending_ = false; // always accessed under mutex_
+    bool shutdown_ = false;       // set in destructor under mutex_
+    std::future<void> unload_future_;
 };

--- a/src/whisper/ModelCache.h
+++ b/src/whisper/ModelCache.h
@@ -196,7 +196,7 @@ private:
         }
     }
 
-    void cancelUnloadLocked() {
+    void cancelUnloadLocked() { // caller holds mutex_
         if (unload_pending_) {
             unload_pending_ = false;
             cv_.notify_all();
@@ -230,6 +230,6 @@ private:
     int ref_count_ = 0;
     int ttl_seconds_ = 300; // default 5 minutes
     bool unload_pending_ = false; // always accessed under mutex_
-    bool shutdown_ = false;       // set in destructor under mutex_
+    bool shutdown_ = false;       // set true in destructor; signals timer task to exit without unloading
     std::future<void> unload_future_;
 };

--- a/src/whisper/ModelCache.h
+++ b/src/whisper/ModelCache.h
@@ -137,6 +137,21 @@ public:
                "transcription_model_ref_count " + std::to_string(ref_count_) + "\n";
     }
 
+    /**
+     * @brief RAII guard that acquires the model on construction and releases on destruction.
+     */
+    class Guard {
+    public:
+        explicit Guard(const std::string& path, bool use_gpu = true)
+            : ctx_(ModelCache::instance().acquire(path, use_gpu)) {}
+        ~Guard() { ModelCache::instance().release(); }
+        whisper_context* ctx() const { return ctx_; }
+        Guard(const Guard&) = delete;
+        Guard& operator=(const Guard&) = delete;
+    private:
+        whisper_context* ctx_;
+    };
+
     // Non-copyable
     ModelCache(const ModelCache&) = delete;
     ModelCache& operator=(const ModelCache&) = delete;

--- a/src/whisper/ModelCache.h
+++ b/src/whisper/ModelCache.h
@@ -92,20 +92,27 @@ public:
      * acquire() happens within ttl_seconds_, the model is freed.
      */
     void release() {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (ref_count_ <= 0) return;
+        std::future<void> old_future;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (ref_count_ <= 0) return;
 
-        --ref_count_;
-        if (ref_count_ == 0) {
-            if (ttl_seconds_ == 0) {
-                // Immediate unload
-                unloadLocked();
-            } else if (ttl_seconds_ > 0) {
-                // Schedule deferred unload
-                scheduleUnloadLocked();
+            --ref_count_;
+            if (ref_count_ == 0) {
+                if (ttl_seconds_ == 0) {
+                    // Immediate unload
+                    unloadLocked();
+                } else if (ttl_seconds_ > 0) {
+                    // Schedule deferred unload; capture old future to drain outside lock
+                    old_future = scheduleUnloadLocked();
+                }
+                // ttl < 0 → keep forever (no-op)
             }
-            // ttl < 0 → keep forever (no-op)
         }
+        // Drain old timer task outside the lock to prevent deadlock:
+        // if old task was notified but hadn't re-acquired mutex yet,
+        // getting the future here (lock released) lets it exit cleanly.
+        if (old_future.valid()) old_future.get();
     }
 
     /**
@@ -196,10 +203,14 @@ private:
         }
     }
 
-    void scheduleUnloadLocked() {
+    std::future<void> scheduleUnloadLocked() {
+        std::future<void> old = std::move(unload_future_);
+        if (old.valid()) {
+            unload_pending_ = false;
+            cv_.notify_all();
+        }
         unload_pending_ = true;
         int ttl = ttl_seconds_;
-
         unload_future_ = std::async(std::launch::async, [this, ttl]() {
             std::unique_lock<std::mutex> lock(mutex_);
             cv_.wait_for(lock, std::chrono::seconds(ttl),
@@ -209,6 +220,7 @@ private:
                 unload_pending_ = false;
             }
         });
+        return old;
     }
 
     mutable std::mutex mutex_;

--- a/src/whisper/ModelCache.h
+++ b/src/whisper/ModelCache.h
@@ -139,6 +139,8 @@ public:
 
     /**
      * @brief RAII guard that acquires the model on construction and releases on destruction.
+     *
+     * Non-movable: use std::optional<Guard> with emplace() for deferred construction.
      */
     class Guard {
     public:
@@ -148,6 +150,7 @@ public:
         whisper_context* ctx() const { return ctx_; }
         Guard(const Guard&) = delete;
         Guard& operator=(const Guard&) = delete;
+        Guard(Guard&&) = delete;
     private:
         whisper_context* ctx_;
     };

--- a/tests/unit/test_model_cache.cpp
+++ b/tests/unit/test_model_cache.cpp
@@ -102,3 +102,14 @@ TEST_F(ModelCacheTest, GuardReleasesOnExceptionPath) {
     } catch (...) {}
     EXPECT_EQ(ModelCache::instance().refCount(), 0);
 }
+
+// Standalone test — runs even when the model file is absent.
+// Verifies that a failed Guard construction (acquire throws) does not call
+// release(), keeping the ref count unchanged. This documents the C++ rule
+// that destructors only run for fully-constructed objects.
+TEST(ModelCacheGuardNoModel, ConstructionThrowDoesNotCallRelease) {
+    ModelCache::instance().forceUnload();
+    int count_before = ModelCache::instance().refCount();
+    EXPECT_THROW(ModelCache::Guard("/nonexistent/model.bin"), std::runtime_error);
+    EXPECT_EQ(ModelCache::instance().refCount(), count_before);
+}

--- a/tests/unit/test_model_cache.cpp
+++ b/tests/unit/test_model_cache.cpp
@@ -81,3 +81,24 @@ TEST_F(ModelCacheTest, MetricsContainExpectedKeys) {
     EXPECT_NE(m.find("transcription_model_ref_count"), std::string::npos);
     ModelCache::instance().release();
 }
+
+TEST_F(ModelCacheTest, GuardAcquiresAndReleasesOnDestruction) {
+    EXPECT_EQ(ModelCache::instance().refCount(), 0);
+    {
+        ModelCache::Guard guard(MODEL_PATH);
+        EXPECT_EQ(ModelCache::instance().refCount(), 1);
+        EXPECT_NE(guard.ctx(), nullptr);
+    }
+    // Guard destroyed → released
+    EXPECT_EQ(ModelCache::instance().refCount(), 0);
+}
+
+TEST_F(ModelCacheTest, GuardReleasesOnExceptionPath) {
+    // Verify the ref count is 0 after a guard scope exits even via exception
+    try {
+        ModelCache::Guard guard(MODEL_PATH);
+        EXPECT_EQ(ModelCache::instance().refCount(), 1);
+        throw std::runtime_error("simulated error");
+    } catch (...) {}
+    EXPECT_EQ(ModelCache::instance().refCount(), 0);
+}


### PR DESCRIPTION
Fixes issues C1, C4, and I2 from the stability roadmap (issue #43).

## Summary

- **C1 — Ref-count leak on exception paths:** Added `ModelCache::Guard` RAII inner class (acquire on construct, release on destruct). Refactored `HandleTranscribe::handle()` to use `std::optional<ModelCache::Guard>`, eliminating 4 scattered `release()` call sites. Model ref-count now released correctly on all paths including exceptions.

- **C4 — Detached timer thread with dangling `this`:** Replaced `std::thread().detach()` in `scheduleUnloadLocked()` with `std::async(std::launch::async, ...)` storing `std::future<void> unload_future_` as member. The destructor awaits the future after signaling shutdown, so the timer task can never outlive the singleton. Fixed an additional deadlock: the old future is moved out of `unload_future_` and drained in `release()` *outside* the lock, preventing the timer task from being blocked on `mutex_` while the future destructor waits for it.

- **I2 — Destructor accesses shared state without mutex:** Destructor now takes `mutex_` before setting `shutdown_` and clearing `unload_pending_`, releases it, notifies the cv, then drains the future and frees `ctx_`.

## Test Plan

- [x] 117/117 tests pass (`./build/tests/unit_tests`)
- [x] New tests: `GuardAcquiresAndReleasesOnDestruction`, `GuardReleasesOnExceptionPath`, `ModelCacheGuardNoModel.ConstructionThrowDoesNotCallRelease`
- [x] Existing TTL tests (`TTLZeroUnloadsImmediately`, `TTLNegativeKeepsModelLoaded`) still pass
- [x] No deadlock under re-schedule race (verified by code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)