### PR TITLE
fix: InferenceLimiter::TryGuard — eliminate TOCTOU and exception slot leak

### DIFF
--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -532,6 +532,8 @@ private:
             Log::debug("flushLoop inference: new=" + std::to_string(current_size - last_transcribed_size_) +
                        " silence_ms=" + std::to_string(elapsed_ms), session_id_);
             // Non-blocking inference: skip cycle if GPU is saturated.
+            // Lock order: state_mutex_ (already held) → InferenceLimiter::mutex_ (taken inside TryGuard).
+            // No inversion risk: InferenceLimiter never acquires state_mutex_.
             InferenceLimiter::TryGuard inf_guard;
             if (!inf_guard.acquired()) {
                 Log::debug("flushLoop: GPU busy, skipping inference cycle", session_id_);

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -532,12 +532,13 @@ private:
             Log::debug("flushLoop inference: new=" + std::to_string(current_size - last_transcribed_size_) +
                        " silence_ms=" + std::to_string(elapsed_ms), session_id_);
             // Non-blocking inference: skip cycle if GPU is saturated.
-            if (!InferenceLimiter::instance().try_acquire()) {
+            InferenceLimiter::TryGuard inf_guard;
+            if (!inf_guard.acquired()) {
                 Log::debug("flushLoop: GPU busy, skipping inference cycle", session_id_);
                 continue;
             }
             auto res = engine_->transcribeSlidingWindow(false);
-            InferenceLimiter::instance().release();
+            // inf_guard releases the slot automatically on scope exit (including exceptions)
 
             // If inference drained the buffer below HWM, reset the overflow flag so the
             // next saturation episode triggers a new warning regardless of client audio timing.

--- a/src/server/handlers/HandleTranscribe.cpp
+++ b/src/server/handlers/HandleTranscribe.cpp
@@ -137,14 +137,6 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
         return;
     }
 
-    // ── 5. Inference capacity check ───────────────────────────────────────────
-    if (!InferenceLimiter::instance().hasCapacity()) {
-        send(makeError(http::status::service_unavailable,
-                       "Server is at maximum inference capacity, try again later",
-                       "server_error", ver));
-        return;
-    }
-
     // ── 6. Acquire model context ──────────────────────────────────────────────
     std::optional<ModelCache::Guard> model_guard;
     try {
@@ -179,9 +171,19 @@ void HandleTranscribe::handle(const http::request<http::string_body>& req,
                     parts.at("task").data.end());
     }
 
+    // ── 7. Acquire inference slot (atomic try — no TOCTOU) ────────────────────
+    // Must be acquired AFTER model_guard so it outlives the inference block.
+    InferenceLimiter::TryGuard inf_guard;
+    if (!inf_guard.acquired()) {
+        // model_guard releases the model automatically on scope exit.
+        send(makeError(http::status::service_unavailable,
+                       "Server is at maximum inference capacity, try again later",
+                       "server_error", ver));
+        return;
+    }
+
     std::string text;
     {
-        InferenceLimiter::Guard guard;
 
         whisper_state* state = whisper_init_state(ctx);
         if (!state) {

--- a/src/whisper/InferenceLimiter.h
+++ b/src/whisper/InferenceLimiter.h
@@ -88,6 +88,22 @@ public:
         Guard& operator=(const Guard&) = delete;
     };
 
+    // Non-blocking RAII guard. Acquires a slot via try_acquire() on construction.
+    // Check acquired() before using. Releases only if a slot was acquired.
+    // Non-movable: use std::optional<TryGuard> with emplace() for deferred construction.
+    class TryGuard {
+    public:
+        TryGuard() : acquired_(InferenceLimiter::instance().try_acquire()) {}
+        ~TryGuard() { if (acquired_) InferenceLimiter::instance().release(); }
+        bool acquired() const { return acquired_; }
+        TryGuard(const TryGuard&) = delete;
+        TryGuard& operator=(const TryGuard&) = delete;
+        TryGuard(TryGuard&&) = delete;
+        TryGuard& operator=(TryGuard&&) = delete;
+    private:
+        bool acquired_;
+    };
+
 private:
     InferenceLimiter() = default;
     ~InferenceLimiter() = default;

--- a/src/whisper/InferenceLimiter.h
+++ b/src/whisper/InferenceLimiter.h
@@ -5,7 +5,7 @@
 
 /**
  * @brief Singleton for limiting concurrent whisper inference calls.
- * 
+ *
  * Prevents GPU OOM and massive latency latency spikes by capping
  * the maximum number of simultaneous whisper_full_with_state() executions.
  */
@@ -26,6 +26,13 @@ public:
             // Unblock waiters in case we increased the limit
             cv_.notify_all();
         }
+    }
+
+    // Test-only: reset active count to 0 without affecting max_concurrent_.
+    void resetForTesting() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        active_count_ = 0;
+        cv_.notify_all();
     }
 
     /**

--- a/tests/unit/test_inference_limiter.cpp
+++ b/tests/unit/test_inference_limiter.cpp
@@ -9,6 +9,7 @@
 class InferenceLimiterTest : public ::testing::Test {
 protected:
     void SetUp() override {
+        InferenceLimiter::instance().resetForTesting();  // ensure clean slate
         InferenceLimiter::instance().setMaxConcurrency(4);
     }
 };

--- a/tests/unit/test_inference_limiter.cpp
+++ b/tests/unit/test_inference_limiter.cpp
@@ -92,3 +92,21 @@ TEST_F(InferenceLimiterTest, TryAcquireSucceedsAfterRelease) {
     EXPECT_TRUE(acquired);
     if (acquired) InferenceLimiter::instance().release();
 }
+
+TEST_F(InferenceLimiterTest, TryGuardAcquiresAndReleasesOnDestruction) {
+    InferenceLimiter::instance().setMaxConcurrency(1);
+    {
+        InferenceLimiter::TryGuard g;
+        EXPECT_TRUE(g.acquired());
+        EXPECT_FALSE(InferenceLimiter::instance().hasCapacity());
+    }
+    EXPECT_TRUE(InferenceLimiter::instance().hasCapacity());
+}
+
+TEST_F(InferenceLimiterTest, TryGuardFailsWhenAtLimit) {
+    InferenceLimiter::instance().setMaxConcurrency(1);
+    InferenceLimiter::Guard occupied; // take the only slot (blocking acquire)
+    InferenceLimiter::TryGuard g;
+    EXPECT_FALSE(g.acquired());
+    // g.acquired()==false means destructor will NOT call release() — no double-free
+}


### PR DESCRIPTION
Fixes issues I4 and I3 from the stability roadmap (issue #44).

## Summary

- **I4 — TOCTOU race in HandleTranscribe:** `hasCapacity()` and `Guard` construction were two separate lock acquisitions, leaving a window where another thread could grab the last slot and cause `Guard` to block indefinitely. Replaced both with `InferenceLimiter::TryGuard`: a single atomic try-acquire that returns immediately if no slot is available, sending 503 to the client. `ModelCache::Guard` releases the model automatically via RAII.

- **I3 — Leaked inference slot on exception:** `flushLoop` in `StreamingSession` called `try_acquire()` manually and released via `InferenceLimiter::instance().release()` — if `transcribeSlidingWindow()` threw, the slot was never released, eventually starving all inference. Replaced with `TryGuard` so the slot releases on every exit path including exceptions.

- **New `InferenceLimiter::TryGuard` class:** Non-blocking RAII guard (calls `try_acquire()` on construction, releases only if acquired). Non-copyable and non-movable; use `emplace()` pattern if deferred construction is needed.

## Test Plan

- [x] 119/119 tests pass (`./build/tests/unit_tests`)
- [x] New tests: `TryGuardAcquiresAndReleasesOnDestruction`, `TryGuardFailsWhenAtLimit`
- [x] Test fixture now calls `resetForTesting()` in `SetUp()` to guarantee clean singleton state between tests
- [x] No TOCTOU window remains in HandleTranscribe (single atomic try-acquire)
- [x] Lock order documented in StreamingSession flushLoop

🤖 Generated with [Claude Code](https://claude.com/claude-code)