### PR TITLE
GPU capacity: bounded waits + status signal + configurable flush cadence

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -151,6 +151,9 @@ ServerConfig configFromEnv() {
     if (auto v = env("WHISPER_LOGPROB_THOLD"); !v.empty())
         cfg.whisper_logprob_thold = std::stof(v);
 
+    if (auto v = env("FLUSH_MIN_NEW_AUDIO_MS"); !v.empty())
+        cfg.flush_min_new_audio_ms = std::stoi(v);
+
     if (auto v = env("SHUTDOWN_TIMEOUT_SEC"); !v.empty())
         cfg.shutdown_timeout_sec = std::stoi(v);
 
@@ -173,7 +176,8 @@ void printUsage(const char* binary) {
               << " [--whisper-beam-size N] [--whisper-threads N]"
               << " [--max-concurrent-inference N] [--model-cache-ttl N]"
               << " [--whisper-initial-prompt TEXT] [--session-timeout-sec N] [--shutdown-timeout-sec N]"
-              << " [--env-file path]" 
+              << " [--flush-min-new-audio-ms N]"
+              << " [--env-file path]"
               << " [--max-upload-bytes N]" << std::endl;
     std::cout << "All options can also be set via environment variables (or a .env file):" << std::endl;
     std::cout << "  MODEL_PATH, BIND_ADDRESS, PORT," << std::endl;
@@ -183,6 +187,7 @@ void printUsage(const char* binary) {
     std::cout << "  MODEL_CACHE_TTL, WHISPER_INITIAL_PROMPT, SESSION_TIMEOUT_SEC, SHUTDOWN_TIMEOUT_SEC," << std::endl;
     std::cout << "  WHISPER_TEMPERATURE, WHISPER_TEMPERATURE_INC," << std::endl;
     std::cout << "  WHISPER_NO_SPEECH_THOLD, WHISPER_LOGPROB_THOLD" << std::endl;
+    std::cout << "  FLUSH_MIN_NEW_AUDIO_MS" << std::endl;
     std::cout << "  MAX_UPLOAD_BYTES" << std::endl;
     std::cout << "CLI arguments override environment variables." << std::endl;
 }
@@ -254,6 +259,8 @@ ServerConfig parseArgs(int argc, char* argv[]) {
             config.whisper_no_speech_thold = std::stof(argv[++i]);
         } else if (arg == "--whisper-logprob-thold" && i + 1 < argc) {
             config.whisper_logprob_thold = std::stof(argv[++i]);
+        } else if (arg == "--flush-min-new-audio-ms" && i + 1 < argc) {
+            config.flush_min_new_audio_ms = std::stoi(argv[++i]);
         } else if (arg == "--thread-safe") {
             // accepted for backwards compatibility
         } else if (arg.rfind("--", 0) != 0 &&
@@ -348,7 +355,8 @@ void handleSession(tcp::socket socket,
                 config.whisper_beam_size, config.whisper_threads,
                 config.whisper_initial_prompt, config.session_timeout_sec,
                 config.whisper_temperature, config.whisper_temperature_inc,
-                config.whisper_no_speech_thold, config.whisper_logprob_thold);
+                config.whisper_no_speech_thold, config.whisper_logprob_thold,
+                config.flush_min_new_audio_ms);
             session->run(req);
         } else {
             boost::beast::http::read(socket, buffer, parser);
@@ -370,7 +378,8 @@ void handleSession(tcp::socket socket,
                 config.whisper_beam_size, config.whisper_threads,
                 config.whisper_initial_prompt, config.session_timeout_sec,
                 config.whisper_temperature, config.whisper_temperature_inc,
-                config.whisper_no_speech_thold, config.whisper_logprob_thold);
+                config.whisper_no_speech_thold, config.whisper_logprob_thold,
+                config.flush_min_new_audio_ms);
             session->run(req);
         }
     } catch (std::exception& e) {
@@ -412,6 +421,7 @@ int main(int argc, char* argv[]) {
                   "  temperature_inc=" + std::to_string(config.whisper_temperature_inc) +
                   "  no_speech_thold=" + std::to_string(config.whisper_no_speech_thold) +
                   "  logprob_thold=" + std::to_string(config.whisper_logprob_thold));
+        Log::info("Flush:   min_new_audio_ms=" + std::to_string(config.flush_min_new_audio_ms));
         if (!config.whisper_initial_prompt.empty()) {
             Log::info("Whisper: initial_prompt=\"" + config.whisper_initial_prompt + "\"");
         }

--- a/src/server/ServerConfig.h
+++ b/src/server/ServerConfig.h
@@ -29,6 +29,7 @@ struct ServerConfig {
     float whisper_temperature_inc = 0.0f;   // temperature increment on repetition (0.0 disables fallback)
     float whisper_no_speech_thold = 0.3f;   // probability threshold to reject non-speech segments
     float whisper_logprob_thold = -0.7f;    // log-prob threshold to reject low-confidence segments (-1.0=disabled)
+    int flush_min_new_audio_ms = 500;       // ms of new audio required before flushLoop re-runs inference (was hardcoded 250ms)
 
     int shutdown_timeout_sec = 10;      // max seconds to wait for sessions to close on SIGINT/SIGTERM
     size_t max_upload_bytes = 25 * 1024 * 1024; // 25 MB — matches OpenAI limit

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -385,13 +385,26 @@ private:
         stopFlushLoop();
 
         std::string final_text;
+        bool complete = true;
+        std::string incomplete_reason;
         {
             std::lock_guard<std::mutex> lock(state_mutex_);
             if (engine_) {
-                auto res = engine_->transcribeSlidingWindow(true); // force commit
-                // Note: no hallucination guard here — this is the last chance to capture audio
-                // that the engine still holds in its buffer.
-                full_transcription_ += res.committed_text;
+                // Bounded wait: don't let the final decode compete indefinitely for a
+                // saturated GPU (jota-project/jota-transcriber#62). If no slot frees up
+                // within the timeout, fall back to whatever was already committed instead
+                // of blocking session close indefinitely.
+                InferenceLimiter::TryGuard guard(std::chrono::milliseconds(3000));
+                if (guard.acquired()) {
+                    auto res = engine_->transcribeSlidingWindow(true); // force commit
+                    // Note: no hallucination guard here — this is the last chance to capture audio
+                    // that the engine still holds in its buffer.
+                    full_transcription_ += res.committed_text;
+                } else {
+                    complete = false;
+                    incomplete_reason = "gpu_saturated_timeout";
+                    Log::warn("handleEnd: timeout esperando slot de inferencia, usando texto parcial/raw acumulado", session_id_);
+                }
             }
 
             // Fallback: if all flushLoop commits were hallucination-filtered (audio was erased
@@ -412,6 +425,10 @@ private:
             {"text", final_text},
             {"is_final", true}
         };
+        if (!complete) {
+            msg["complete"] = false;
+            msg["reason"] = incomplete_reason;
+        }
         sendMessage(msg);
 
         try {

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -56,6 +56,7 @@ public:
           auth_manager_(auth_manager),
           configured_(false),
           buffer_overflowed_(false),
+          capacity_degraded_(false),
           last_transcribed_size_(0),
           language_("es"),
           whisper_beam_size_(whisper_beam_size),
@@ -365,6 +366,7 @@ private:
 
                 configured_ = true;
                 last_transcribed_size_ = 0;
+                capacity_degraded_ = false;
                 full_transcription_    = "";
                 raw_transcription_     = "";
                 last_audio_time_ = std::chrono::steady_clock::now();
@@ -473,6 +475,7 @@ private:
     std::string session_id_;
     bool configured_;
     bool buffer_overflowed_; // true while engine buffer is above 20s HWM
+    bool capacity_degraded_; // true while this session's own inference cycles are being skipped (GPU saturated)
     size_t last_transcribed_size_;
     std::string language_;
 
@@ -561,7 +564,21 @@ private:
             InferenceLimiter::TryGuard inf_guard;
             if (!inf_guard.acquired()) {
                 Log::debug("flushLoop: GPU busy, skipping inference cycle", session_id_);
+                if (!capacity_degraded_) {
+                    capacity_degraded_ = true;
+                    Log::warn("flushLoop: entrando en estado busy (gpu_saturated)", session_id_);
+                    lock.unlock();
+                    sendMessage({{"type", "status"}, {"state", "busy"}, {"reason", "gpu_saturated"}});
+                    lock.lock();
+                }
                 continue;
+            }
+            if (capacity_degraded_) {
+                capacity_degraded_ = false;
+                Log::info("flushLoop: saliendo de estado busy", session_id_);
+                lock.unlock();
+                sendMessage({{"type", "status"}, {"state", "ok"}});
+                lock.lock();
             }
             auto res = engine_->transcribeSlidingWindow(false);
             // inf_guard releases the slot automatically on scope exit (including exceptions)

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -29,6 +29,11 @@ namespace net = boost::asio;
 using tcp = net::ip::tcp;
 using json = nlohmann::json;
 
+// ms of audio @16kHz mono float32 → sample count.
+inline size_t msToSamples16kHz(int ms) {
+    return static_cast<size_t>(ms) * 16;
+}
+
 template <class StreamType>
 class StreamingSession : public std::enable_shared_from_this<StreamingSession<StreamType>>, public SessionTracker::SessionBase {
 public:
@@ -43,7 +48,8 @@ public:
         float whisper_temperature = 0.2f,
         float whisper_temperature_inc = 0.2f,
         float whisper_no_speech_thold = 0.3f,
-        float whisper_logprob_thold = -1.0f
+        float whisper_logprob_thold = -1.0f,
+        int flush_min_new_audio_ms = 500
     )
         : ws_(std::move(ws)),
           model_path_(model_path),
@@ -60,6 +66,7 @@ public:
           whisper_temperature_inc_(whisper_temperature_inc),
           whisper_no_speech_thold_(whisper_no_speech_thold),
           whisper_logprob_thold_(whisper_logprob_thold),
+          flush_min_new_audio_ms_(flush_min_new_audio_ms),
           model_acquired_(false),
           bytes_received_in_window_(0),
           rate_limit_start_(std::chrono::steady_clock::now()),
@@ -478,6 +485,7 @@ private:
     float whisper_temperature_inc_;
     float whisper_no_speech_thold_;
     float whisper_logprob_thold_;
+    int flush_min_new_audio_ms_;
     bool model_acquired_;
     
     // Rate limiting & Timeout
@@ -514,7 +522,7 @@ private:
         // Handles ALL inference, decoupled from the WebSocket receive loop.
         // Triggers on: 250ms of new audio accumulated, OR 400ms of silence with unprocessed audio.
         // Does NOT trigger if buffer < 2s: Whisper hallucinates badly on very short windows.
-        const size_t MIN_NEW_SAMPLES    = 4000;  // 250ms @ 16kHz
+        const size_t MIN_NEW_SAMPLES    = msToSamples16kHz(flush_min_new_audio_ms_);
         const size_t MIN_BUFFER_SAMPLES = 32000; // 2s minimum before first inference
 
         while (flush_running_) {

--- a/src/whisper/InferenceLimiter.h
+++ b/src/whisper/InferenceLimiter.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <mutex>
 #include <condition_variable>
+#include <chrono>
 #include <iostream>
 
 /**
@@ -58,6 +59,19 @@ public:
     }
 
     /**
+     * @brief Try to acquire an inference slot, waiting up to `timeout` if none is free.
+     * @return true if a slot was acquired before the timeout elapsed, false otherwise.
+     */
+    bool try_acquire_for(std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (cv_.wait_for(lock, timeout, [this]() { return active_count_ < max_concurrent_; })) {
+            ++active_count_;
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * @brief Release an inference slot, waking up one waiting thread.
      */
     void release() {
@@ -101,6 +115,8 @@ public:
     class TryGuard {
     public:
         TryGuard() : acquired_(InferenceLimiter::instance().try_acquire()) {}
+        explicit TryGuard(std::chrono::milliseconds timeout)
+            : acquired_(InferenceLimiter::instance().try_acquire_for(timeout)) {}
         ~TryGuard() { if (acquired_) InferenceLimiter::instance().release(); }
         bool acquired() const { return acquired_; }
         TryGuard(const TryGuard&) = delete;

--- a/tests/unit/test_inference_limiter.cpp
+++ b/tests/unit/test_inference_limiter.cpp
@@ -111,3 +111,48 @@ TEST_F(InferenceLimiterTest, TryGuardFailsWhenAtLimit) {
     EXPECT_FALSE(g.acquired());
     // g.acquired()==false means destructor will NOT call release() — no double-free
 }
+
+TEST_F(InferenceLimiterTest, TryAcquireForSucceedsWhenSlotFreesWithinTimeout) {
+    InferenceLimiter::instance().setMaxConcurrency(1);
+    auto guard = std::make_unique<InferenceLimiter::Guard>(); // occupy the only slot
+
+    std::thread releaser([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        guard.reset(); // free the slot partway through the wait
+    });
+
+    bool acquired = InferenceLimiter::instance().try_acquire_for(std::chrono::milliseconds(500));
+    releaser.join();
+
+    EXPECT_TRUE(acquired);
+    if (acquired) InferenceLimiter::instance().release();
+}
+
+TEST_F(InferenceLimiterTest, TryAcquireForFailsWhenTimeoutExpires) {
+    InferenceLimiter::instance().setMaxConcurrency(1);
+    InferenceLimiter::Guard occupied; // never released during this test
+
+    auto start = std::chrono::steady_clock::now();
+    bool acquired = InferenceLimiter::instance().try_acquire_for(std::chrono::milliseconds(100));
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_FALSE(acquired);
+    EXPECT_GE(elapsed, std::chrono::milliseconds(100));
+}
+
+TEST_F(InferenceLimiterTest, TryGuardWithTimeoutAcquiresAndReleasesOnDestruction) {
+    InferenceLimiter::instance().setMaxConcurrency(1);
+    {
+        InferenceLimiter::TryGuard g(std::chrono::milliseconds(100));
+        EXPECT_TRUE(g.acquired());
+        EXPECT_FALSE(InferenceLimiter::instance().hasCapacity());
+    }
+    EXPECT_TRUE(InferenceLimiter::instance().hasCapacity());
+}
+
+TEST_F(InferenceLimiterTest, TryGuardWithTimeoutFailsWhenSlotNeverFrees) {
+    InferenceLimiter::instance().setMaxConcurrency(1);
+    InferenceLimiter::Guard occupied;
+    InferenceLimiter::TryGuard g(std::chrono::milliseconds(100));
+    EXPECT_FALSE(g.acquired());
+}

--- a/tests/unit/test_streaming_session.cpp
+++ b/tests/unit/test_streaming_session.cpp
@@ -13,6 +13,7 @@
 #include <thread>
 #include <memory>
 #include <atomic>
+#include <cstring>
 
 namespace beast = boost::beast;
 namespace http = beast::http;
@@ -302,6 +303,36 @@ TEST_F(StreamingSessionTest, HandleEndFallsBackWhenGpuSaturated) {
     EXPECT_TRUE(trans["is_final"]);
     EXPECT_EQ(trans["complete"], false);
     EXPECT_EQ(trans["reason"], "gpu_saturated_timeout");
+}
+
+TEST_F(StreamingSessionTest, EmitsStatusBusyThenOkAroundGpuSaturation) {
+    auto port = startServer(false);
+    auto client = connect(port);
+
+    client.sendJson({{"type", "config"}, {"language", "es"}});
+    EXPECT_EQ(client.recvJson()["type"], "ready");
+
+    // Ocupamos el único slot (max_concurrency=1) para que el flushLoop de
+    // esta sesión no pueda adquirirlo.
+    auto occupied = std::make_unique<InferenceLimiter::Guard>();
+
+    // >2s de silencio @16kHz float32 — cruza MIN_BUFFER_SAMPLES (2s) y
+    // dispara el intento de inferencia en flushLoop.
+    std::vector<float> silence(33600, 0.0f);
+    std::vector<unsigned char> bytes(silence.size() * sizeof(float));
+    std::memcpy(bytes.data(), silence.data(), bytes.size());
+    client.sendBinary(bytes);
+
+    auto status1 = client.recvJson();
+    EXPECT_EQ(status1["type"], "status");
+    EXPECT_EQ(status1["state"], "busy");
+    EXPECT_EQ(status1["reason"], "gpu_saturated");
+
+    occupied.reset(); // libera el slot
+
+    auto status2 = client.recvJson();
+    EXPECT_EQ(status2["type"], "status");
+    EXPECT_EQ(status2["state"], "ok");
 }
 
 TEST_F(StreamingSessionTest, DoubleConfig) {

--- a/tests/unit/test_streaming_session.cpp
+++ b/tests/unit/test_streaming_session.cpp
@@ -284,6 +284,26 @@ TEST_F(StreamingSessionTest, ExactlyOneIsFinalAndIsLastMessage) {
         << "Last message must be is_final=true, but got: " << msgs.back().dump();
 }
 
+TEST_F(StreamingSessionTest, HandleEndFallsBackWhenGpuSaturated) {
+    auto port = startServer(false);
+    auto client = connect(port);
+
+    client.sendJson({{"type", "config"}, {"language", "es"}});
+    EXPECT_EQ(client.recvJson()["type"], "ready");
+
+    // SetUp() fija max_concurrency=1. Ocupamos el único slot durante todo
+    // el test para forzar que el TryGuard acotado de handleEnd() (3s) expire.
+    InferenceLimiter::Guard occupied;
+
+    client.sendJson({{"type", "end"}});
+    auto trans = client.recvJson();
+
+    EXPECT_EQ(trans["type"], "transcription");
+    EXPECT_TRUE(trans["is_final"]);
+    EXPECT_EQ(trans["complete"], false);
+    EXPECT_EQ(trans["reason"], "gpu_saturated_timeout");
+}
+
 TEST_F(StreamingSessionTest, DoubleConfig) {
     auto port = startServer(false);
     auto client = connect(port);

--- a/tests/unit/test_streaming_session.cpp
+++ b/tests/unit/test_streaming_session.cpp
@@ -318,3 +318,10 @@ TEST_F(StreamingSessionTest, DoubleConfig) {
     EXPECT_EQ(msg2["type"], "ready");
     EXPECT_EQ(msg2["config"]["language"], "en");
 }
+
+TEST(MsToSamples16kHzTest, ConvertsMillisecondsToSampleCount) {
+    EXPECT_EQ(msToSamples16kHz(500), 8000u);
+    EXPECT_EQ(msToSamples16kHz(250), 4000u);   // valor por defecto anterior
+    EXPECT_EQ(msToSamples16kHz(1000), 16000u);
+    EXPECT_EQ(msToSamples16kHz(0), 0u);
+}


### PR DESCRIPTION
## Summary
Cierra la parte de responsabilidad de este repo en [Jota-project/jota-transcriber#62](https://github.com/Jota-project/jota-transcriber/issues/62): que la decodificación final no compita sin control por GPU saturada, que la sesión afectada reciba una señal explícita en vez de degradarse en silencio, y reducir la frecuencia de reprocesado que provoca la saturación.

- `InferenceLimiter::try_acquire_for(timeout)` / `TryGuard(timeout)`: espera acotada con timeout para adquirir un slot de inferencia.
- `handleEnd()` usa la espera acotada (3s) y, si expira, añade `"complete": false` / `"reason": "gpu_saturated_timeout"` al mensaje final en vez de bloquear indefinidamente.
- Frecuencia de reprocesado de `flushLoop()` configurable vía `--flush-min-new-audio-ms` / `FLUSH_MIN_NEW_AUDIO_MS` (default 500ms, antes hardcodeado a 250ms).
- `flushLoop()` emite `{"type":"status","state":"busy","reason":"gpu_saturated"}` / `{"type":"status","state":"ok"}` por sesión en las transiciones de saturación de GPU.

Todo el protocolo WS nuevo es aditivo — clientes existentes que ignoren los campos/mensajes nuevos no se rompen.

## Test plan
- [x] `./run_tests.sh` — 82 passed, 48 skipped (modelos completos no disponibles en este entorno, mismo baseline previo), 0 failures
- [x] Build completo del servidor (`BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF`) sin errores
- [ ] Smoke test manual con `--max-concurrent-inference 1` y dos sesiones WS simultáneas (recomendado antes de desplegar, ver plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)