### PR TITLE
ci: align workflow to STANDARDS.md — rename to test.yml, job to test, add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code ownership — all files require review from SitoSt
+* @SitoSt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,13 @@
-name: CI
+name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '**' ]
   pull_request:
     branches: [ main ]
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Renombra el workflow de CI y añade CODEOWNERS para alinearse con STANDARDS.md de la organización Jota-project.

## Changes

- ** → **: el ruleset de  exige que el job tenga id `test`
- **Job `build-and-test` → `test`**: nombre exigido por el status check requerido
- **Workflow name `CI` → `Tests`**: convención de la organización
- **Push trigger**: ampliado a todas las ramas (`**`), antes solo `main`
- ****: añadido con `* @SitoSt` para que aplique la regla `require_code_owner_review`

## Testing

El propio CI de este PR verifica que el check `test` aparece y pasa.

Closes #66