### PR TITLE
fix: sessions colgadas y límite por IP (#68 #69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,9 @@ TLS_KEY=server.key
 MAX_CONNECTIONS=8
 MAX_CONNECTIONS_PER_IP=2
 
+# Trusted proxy exemption (leave TRUSTED_PROXY_HOSTS empty to disable — default)
+# CSV hostnames exempt from MAX_CONNECTIONS_PER_IP (e.g. a shared gateway).
+# See README.md "Trusted Proxy Exemption" section before enabling.
+#TRUSTED_PROXY_HOSTS=jota-gateway
+TRUSTED_PROXY_REFRESH_SEC=30
+

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ TLS_KEY=server.key
 MAX_CONNECTIONS=8
 MAX_CONNECTIONS_PER_IP=2
 
+# Session and handshake timeouts
+# session_timeout_sec: idle session disconnect (seconds). Default: 30
+# handshake_timeout_sec: TLS/HTTP-upgrade handshake deadline (seconds). Default: 10
+SESSION_TIMEOUT_SEC=30
+HANDSHAKE_TIMEOUT_SEC=10
+
 # Trusted proxy exemption (leave TRUSTED_PROXY_HOSTS empty to disable — default)
 # CSV hostnames exempt from MAX_CONNECTIONS_PER_IP (e.g. a shared gateway).
 # See README.md "Trusted Proxy Exemption" section before enabling.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ if(BUILD_SERVER)
         src/server/StreamingSession.cpp
         src/server/AuthManager.cpp
         src/server/ConnectionLimiter.cpp
+        src/server/TrustedProxyResolver.cpp
         src/server/ConnectionGuard.cpp
         src/auth/ApiAuthClient.cpp
         src/auth/AuthCache.cpp

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Always build with `-DBUILD_SHARED_LIBS=OFF`. whisper.cpp defaults to shared libs
 ## Testing
 
 ```bash
-./run_tests.sh                                      # all 140 tests
+./run_tests.sh                                      # all 144 tests
 ./build/tests/unit_tests --gtest_filter=AudioPipeline*      # one suite
 ./build/tests/unit_tests --gtest_filter=-*ModelCache*       # skip model-dependent
 ```
@@ -274,7 +274,7 @@ Always build with `-DBUILD_SHARED_LIBS=OFF`. whisper.cpp defaults to shared libs
 | `test_audio_pipeline.cpp` | 8 | No |
 | `test_inference_limiter.cpp` | 14 | No |
 | `test_connection_limiter.cpp` | 10 | No |
-| `test_trusted_proxy_resolver.cpp` | 7 | No |
+| `test_trusted_proxy_resolver.cpp` | 11 | No |
 | `test_session_tracker.cpp` | 4 | No |
 | `test_model_cache.cpp` | 10 | Yes |
 | `test_streaming_whisper_engine.cpp` | 25 | Yes |

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ All flags are also available as environment variables (see `.env.example`).
 - **docker-compose / same host** — this repo's `docker-compose.yml` uses `network_mode: host`, so the gateway and transcriber share the host's network namespace; `--trusted-proxy-hosts localhost` (or the host's own hostname) is usually correct.
 - **Kubernetes** — point at the gateway's Service DNS name, e.g. `--trusted-proxy-hosts jota-gateway.default.svc.cluster.local`. CoreDNS resolves it to the current pod IP(s) on each refresh, so pod restarts/rescheduling don't require a config change.
 - **Dual-stack caveat** — on a dual-stack bind (`--bind ::`), Boost.Asio reports IPv4 peers as `::ffff:a.b.c.d`, but DNS resolution returns bare IPv4 addresses, so an IPv4 trusted host won't match in that setup. This fails closed (not a security issue), but is a silent no-op worth knowing about when troubleshooting.
-- **DNS-outage caveat** — resolution runs synchronously in the accept loop; a stalled DNS lookup can delay accepting *any* new connection (trusted or not) for up to the lookup's own timeout, once per refresh window. Tracked as a possible fast-follow in [#73](https://github.com/Jota-project/jota-transcriber/issues/73).
 
 ## WebSocket Protocol
 
@@ -274,7 +273,7 @@ Always build with `-DBUILD_SHARED_LIBS=OFF`. whisper.cpp defaults to shared libs
 | `test_audio_pipeline.cpp` | 8 | No |
 | `test_inference_limiter.cpp` | 14 | No |
 | `test_connection_limiter.cpp` | 10 | No |
-| `test_trusted_proxy_resolver.cpp` | 11 | No |
+| `test_trusted_proxy_resolver.cpp` | 12 | No |
 | `test_session_tracker.cpp` | 4 | No |
 | `test_model_cache.cpp` | 10 | Yes |
 | `test_streaming_whisper_engine.cpp` | 25 | Yes |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ High-performance real-time audio transcription microservice built with C++17 and
 - Real-time streaming with partial transcriptions while audio is being sent
 - WebSocket (WS) and WebSocket over TLS (WSS)
 - Authentication: static token or external API with in-memory cache
-- Per-IP and global connection limits
+- Per-IP and global connection limits, with an opt-in DNS-based exemption for a trusted gateway proxy
 - Non-blocking inference — GPU saturation skips a cycle instead of blocking
 - Audio buffer high-water mark (20s) with client-side warning
 - Hallucination guard against Whisper decoder loops
@@ -78,6 +78,12 @@ cd third_party/whisper.cpp/models
   --auth-api-url http://auth-service:8080/validate \
   --auth-api-secret API_SECRET
 
+# With a trusted gateway proxy (exempt from the per-IP cap — see below)
+./build/jota-transcriber \
+  --model /path/to/ggml-small.bin \
+  --max-connections 8 --max-connections-per-ip 2 \
+  --trusted-proxy-hosts jota-gateway --trusted-proxy-refresh-sec 30
+
 # Generate self-signed certs for development
 ./generate_certs.sh
 ```
@@ -122,6 +128,8 @@ Model files must be placed in `./models/` before starting (mounted at `/app/mode
 | `--auth-api-timeout N` | `5` | Auth API request timeout in seconds |
 | `--max-connections N` | `8` | Global connection cap |
 | `--max-connections-per-ip N` | `2` | Per-IP connection cap |
+| `--trusted-proxy-hosts HOSTS` | — | CSV hostnames exempt from the per-IP cap (empty = disabled). See [Trusted Proxy Exemption](#trusted-proxy-exemption-per-ip-limit) |
+| `--trusted-proxy-refresh-sec N` | `30` | DNS re-resolution interval for `--trusted-proxy-hosts` |
 | `--session-timeout-sec N` | `30` | Idle session timeout |
 | `--shutdown-timeout-sec N` | `10` | Graceful shutdown wait |
 | `--whisper-beam-size N` | `1` | Beam size (1 = greedy, fastest) |
@@ -131,6 +139,31 @@ Model files must be placed in `./models/` before starting (mounted at `/app/mode
 | `--whisper-initial-prompt TEXT` | — | Decoder initial prompt for vocabulary guidance |
 
 All flags are also available as environment variables (see `.env.example`).
+
+## Trusted Proxy Exemption (Per-IP Limit)
+
+`--max-connections-per-ip` caps how many simultaneous sessions a single IP can hold, to stop one client from monopolizing the service. In production the only real client is often a single shared gateway process (e.g. `jota-gateway`) proxying many real users from one IP — which turns the per-IP cap into a de-facto global cap, independent of how many real users are active.
+
+`--trusted-proxy-hosts` exempts a configured gateway (identified by hostname, resolved via DNS) from the per-IP cap. This **only** widens the per-IP allowance — the global `--max-connections` cap and authentication (`--auth-token` / `--auth-api-url`) are never affected.
+
+**How it works:**
+- Configure one or more hostnames (not IPs), comma-separated. Empty (the default) = feature off, zero behavior change.
+- Every `--trusted-proxy-refresh-sec` seconds (default `30`), the server re-resolves each hostname via `getaddrinfo` (IPv4 + IPv6) and caches the result.
+- **Fail-closed:** a hostname that has never resolved trusts nothing. A later transient resolution failure keeps that host's last known-good IPs — one flaky host among several doesn't undo another host's trust.
+- Internals: `src/server/TrustedProxyResolver.h` / `.cpp`.
+
+**Configuration:**
+
+| CLI flag | Env var | Default | Description |
+|---|---|---|---|
+| `--trusted-proxy-hosts HOSTS` | `TRUSTED_PROXY_HOSTS` | *(empty = disabled)* | Comma-separated hostnames exempt from the per-IP cap |
+| `--trusted-proxy-refresh-sec N` | `TRUSTED_PROXY_REFRESH_SEC` | `30` | DNS re-resolution interval in seconds |
+
+**Deploy scenarios:**
+- **docker-compose / same host** — this repo's `docker-compose.yml` uses `network_mode: host`, so the gateway and transcriber share the host's network namespace; `--trusted-proxy-hosts localhost` (or the host's own hostname) is usually correct.
+- **Kubernetes** — point at the gateway's Service DNS name, e.g. `--trusted-proxy-hosts jota-gateway.default.svc.cluster.local`. CoreDNS resolves it to the current pod IP(s) on each refresh, so pod restarts/rescheduling don't require a config change.
+- **Dual-stack caveat** — on a dual-stack bind (`--bind ::`), Boost.Asio reports IPv4 peers as `::ffff:a.b.c.d`, but DNS resolution returns bare IPv4 addresses, so an IPv4 trusted host won't match in that setup. This fails closed (not a security issue), but is a silent no-op worth knowing about when troubleshooting.
+- **DNS-outage caveat** — resolution runs synchronously in the accept loop; a stalled DNS lookup can delay accepting *any* new connection (trusted or not) for up to the lookup's own timeout, once per refresh window. Tracked as a possible fast-follow in [#73](https://github.com/Jota-project/jota-transcriber/issues/73).
 
 ## WebSocket Protocol
 
@@ -230,19 +263,20 @@ Always build with `-DBUILD_SHARED_LIBS=OFF`. whisper.cpp defaults to shared libs
 ## Testing
 
 ```bash
-./run_tests.sh                                      # all 68 tests
+./run_tests.sh                                      # all 140 tests
 ./build/tests/unit_tests --gtest_filter=AudioPipeline*      # one suite
 ./build/tests/unit_tests --gtest_filter=-*ModelCache*       # skip model-dependent
 ```
 
 | Test file | Tests | Needs model |
 |---|---|---|
-| `test_hallucination_guard.cpp` | 9 | No |
+| `test_hallucination_guard.cpp` | 10 | No |
 | `test_audio_pipeline.cpp` | 8 | No |
-| `test_inference_limiter.cpp` | 8 | No |
-| `test_connection_limiter.cpp` | 7 | No |
+| `test_inference_limiter.cpp` | 14 | No |
+| `test_connection_limiter.cpp` | 10 | No |
+| `test_trusted_proxy_resolver.cpp` | 7 | No |
 | `test_session_tracker.cpp` | 4 | No |
-| `test_model_cache.cpp` | 7 | Yes |
+| `test_model_cache.cpp` | 10 | Yes |
 | `test_streaming_whisper_engine.cpp` | 25 | Yes |
 
 ## Client Examples

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -17,6 +17,7 @@
 #include "server/ServerConfig.h"
 #include "server/ConnectionLimiter.h"
 #include "server/ConnectionGuard.h"
+#include "server/HandshakeWatchdog.h"
 #include "server/TrustedProxyResolver.h"
 #include "server/AuthManager.h"
 #include "auth/ApiAuthConfig.h"
@@ -146,6 +147,9 @@ ServerConfig configFromEnv() {
     if (auto v = env("SESSION_TIMEOUT_SEC"); !v.empty())
         cfg.session_timeout_sec = std::stoi(v);
 
+    if (auto v = env("HANDSHAKE_TIMEOUT_SEC"); !v.empty())
+        cfg.handshake_timeout_sec = std::stoi(v);
+
     if (auto v = env("WHISPER_TEMPERATURE"); !v.empty())
         cfg.whisper_temperature = std::stof(v);
 
@@ -183,7 +187,7 @@ void printUsage(const char* binary) {
               << " [--trusted-proxy-hosts HOSTS] [--trusted-proxy-refresh-sec N]"
               << " [--whisper-beam-size N] [--whisper-threads N]"
               << " [--max-concurrent-inference N] [--model-cache-ttl N]"
-              << " [--whisper-initial-prompt TEXT] [--session-timeout-sec N] [--shutdown-timeout-sec N]"
+              << " [--whisper-initial-prompt TEXT] [--session-timeout-sec N] [--handshake-timeout-sec N] [--shutdown-timeout-sec N]"
               << " [--flush-min-new-audio-ms N]"
               << " [--vad-model PATH] [--vad-threshold F] [--vad-min-speech-ms N]"
               << " [--vad-min-silence-ms N] [--vad-max-speech-s F] [--vad-speech-pad-ms N]"
@@ -203,7 +207,7 @@ void printUsage(const char* binary) {
     std::cout << "  TLS_CERT, TLS_KEY, MAX_CONNECTIONS, MAX_CONNECTIONS_PER_IP," << std::endl;
     std::cout << "  TRUSTED_PROXY_HOSTS, TRUSTED_PROXY_REFRESH_SEC," << std::endl;
     std::cout << "  WHISPER_BEAM_SIZE, WHISPER_THREADS, MAX_CONCURRENT_INFERENCE," << std::endl;
-    std::cout << "  MODEL_CACHE_TTL, WHISPER_INITIAL_PROMPT, SESSION_TIMEOUT_SEC, SHUTDOWN_TIMEOUT_SEC," << std::endl;
+    std::cout << "  MODEL_CACHE_TTL, WHISPER_INITIAL_PROMPT, SESSION_TIMEOUT_SEC, HANDSHAKE_TIMEOUT_SEC, SHUTDOWN_TIMEOUT_SEC," << std::endl;
     std::cout << "  WHISPER_TEMPERATURE, WHISPER_TEMPERATURE_INC," << std::endl;
     std::cout << "  WHISPER_NO_SPEECH_THOLD, WHISPER_LOGPROB_THOLD" << std::endl;
     std::cout << "  FLUSH_MIN_NEW_AUDIO_MS" << std::endl;
@@ -272,6 +276,8 @@ ServerConfig parseArgs(int argc, char* argv[]) {
             config.whisper_initial_prompt = argv[++i];
         } else if (arg == "--session-timeout-sec" && i + 1 < argc) {
             config.session_timeout_sec = std::stoi(argv[++i]);
+        } else if (arg == "--handshake-timeout-sec" && i + 1 < argc) {
+            config.handshake_timeout_sec = std::stoi(argv[++i]);
         } else if (arg == "--shutdown-timeout-sec" && i + 1 < argc) {
             config.shutdown_timeout_sec = std::stoi(argv[++i]);
         } else if (arg == "--whisper-temperature" && i + 1 < argc) {
@@ -355,6 +361,16 @@ void handleSession(tcp::socket socket,
                    std::shared_ptr<ssl::context> ssl_ctx) {
     ConnectionGuard guard(limiter, client_ip);
 
+    // The ConnectionGuard slot above is held from here on. Before the
+    // StreamingSession exists (and takes over via its own idle watchdog,
+    // jota-transcriber#68), the TLS handshake and the initial HTTP upgrade
+    // read below have no timeout at all otherwise: a client that opens a
+    // TCP connection and sends nothing (or trickles data arbitrarily
+    // slowly) would hold this slot forever. native_handle() is captured
+    // before any std::move below — it's the same OS-level fd regardless of
+    // which C++ wrapper currently owns it.
+    HandshakeWatchdog handshake_watchdog(socket.native_handle(), config.handshake_timeout_sec);
+
     try {
         boost::beast::flat_buffer buffer;
         http::request_parser<http::string_body> parser;
@@ -387,6 +403,9 @@ void handleSession(tcp::socket socket,
             }
 
             websocket::stream<ssl::stream<tcp::socket>> ws(std::move(ssl_stream));
+            // From here on, StreamingSession's own idle watchdog (flushLoop)
+            // owns this connection's timeout protection.
+            handshake_watchdog.disarm();
             auto session = std::make_shared<StreamingSession<websocket::stream<ssl::stream<tcp::socket>>>>(
                 std::move(ws), config.model_path, auth_manager,
                 config.whisper_beam_size, config.whisper_threads,
@@ -414,6 +433,9 @@ void handleSession(tcp::socket socket,
             }
 
             websocket::stream<tcp::socket> ws(std::move(socket));
+            // From here on, StreamingSession's own idle watchdog (flushLoop)
+            // owns this connection's timeout protection.
+            handshake_watchdog.disarm();
             auto session = std::make_shared<StreamingSession<websocket::stream<tcp::socket>>>(
                 std::move(ws), config.model_path, auth_manager,
                 config.whisper_beam_size, config.whisper_threads,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -465,12 +465,30 @@ int main(int argc, char* argv[]) {
             config.max_connections_per_ip
         );
 
-        auto trusted_resolver = std::make_shared<TrustedProxyResolver>(
-            config.trusted_proxy_hosts,
-            config.trusted_proxy_refresh_sec
-        );
+        auto trusted_resolver = std::make_shared<TrustedProxyResolver>(config.trusted_proxy_hosts);
+
+        // Refreshing trusted-proxy DNS runs on its own thread so a stalled
+        // lookup (DNS outage) can never delay the accept loop below.
+        // isTrusted() only ever reads the cache TrustedProxyResolver::refresh()
+        // last wrote; see TrustedProxyResolver.h for the concurrency contract.
+        std::atomic<bool> stop_trusted_refresh{false};
+        std::thread trusted_refresh_thread;
         if (trusted_resolver->enabled()) {
             Log::info("Trusted proxies (per-IP limit exempt): " + config.trusted_proxy_hosts);
+            trusted_refresh_thread = std::thread(
+                [trusted_resolver, &stop_trusted_refresh,
+                 refresh_sec = config.trusted_proxy_refresh_sec]() {
+                    trusted_resolver->refresh();  // resolve once immediately at startup
+                    while (!stop_trusted_refresh) {
+                        auto deadline = std::chrono::steady_clock::now() +
+                                        std::chrono::seconds(refresh_sec);
+                        while (!stop_trusted_refresh &&
+                               std::chrono::steady_clock::now() < deadline) {
+                            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                        }
+                        if (!stop_trusted_refresh) trusted_resolver->refresh();
+                    }
+                });
         }
 
         ApiAuthConfig auth_config;
@@ -497,6 +515,7 @@ int main(int argc, char* argv[]) {
             Log::info("Signal " + std::to_string(signum) + " received — stopping accept loop");
             acceptor.close();
             SessionTracker::instance().shutdownAll();
+            stop_trusted_refresh = true;
         });
 
         while (acceptor.is_open()) {
@@ -564,6 +583,8 @@ int main(int argc, char* argv[]) {
         for (auto& t : session_threads) {
             if (t.joinable()) t.join();
         }
+
+        if (trusted_refresh_thread.joinable()) trusted_refresh_thread.join();
 
         ioc.stop();
         if (ioc_thread.joinable()) ioc_thread.join();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -17,6 +17,7 @@
 #include "server/ServerConfig.h"
 #include "server/ConnectionLimiter.h"
 #include "server/ConnectionGuard.h"
+#include "server/TrustedProxyResolver.h"
 #include "server/AuthManager.h"
 #include "auth/ApiAuthConfig.h"
 #include "whisper/ModelCache.h"
@@ -119,6 +120,12 @@ ServerConfig configFromEnv() {
 
     if (auto v = env("MAX_CONNECTIONS_PER_IP"); !v.empty())
         cfg.max_connections_per_ip = static_cast<size_t>(std::stoul(v));
+
+    if (auto v = env("TRUSTED_PROXY_HOSTS"); !v.empty())
+        cfg.trusted_proxy_hosts = v;
+
+    if (auto v = env("TRUSTED_PROXY_REFRESH_SEC"); !v.empty())
+        cfg.trusted_proxy_refresh_sec = std::stoi(v);
 
     // Whisper quality params
     if (auto v = env("WHISPER_BEAM_SIZE"); !v.empty())
@@ -237,6 +244,10 @@ ServerConfig parseArgs(int argc, char* argv[]) {
             config.max_connections = static_cast<size_t>(std::stoul(argv[++i]));
         } else if (arg == "--max-connections-per-ip" && i + 1 < argc) {
             config.max_connections_per_ip = static_cast<size_t>(std::stoul(argv[++i]));
+        } else if (arg == "--trusted-proxy-hosts" && i + 1 < argc) {
+            config.trusted_proxy_hosts = argv[++i];
+        } else if (arg == "--trusted-proxy-refresh-sec" && i + 1 < argc) {
+            config.trusted_proxy_refresh_sec = std::stoi(argv[++i]);
         } else if (arg == "--whisper-beam-size" && i + 1 < argc) {
             config.whisper_beam_size = std::stoi(argv[++i]);
         } else if (arg == "--whisper-threads" && i + 1 < argc) {
@@ -452,6 +463,14 @@ int main(int argc, char* argv[]) {
             config.max_connections_per_ip
         );
 
+        auto trusted_resolver = std::make_shared<TrustedProxyResolver>(
+            config.trusted_proxy_hosts,
+            config.trusted_proxy_refresh_sec
+        );
+        if (trusted_resolver->enabled()) {
+            Log::info("Trusted proxies (per-IP limit exempt): " + config.trusted_proxy_hosts);
+        }
+
         ApiAuthConfig auth_config;
         auth_config.static_token      = config.auth_token;
         auth_config.api_base_url      = config.auth_api_url;
@@ -493,14 +512,16 @@ int main(int argc, char* argv[]) {
             }
 
             std::string client_ip = socket.remote_endpoint().address().to_string();
+            bool trusted = trusted_resolver->isTrusted(client_ip);
 
-            if (!limiter->tryAcquire(client_ip)) {
+            if (!limiter->tryAcquire(client_ip, trusted)) {
                 Log::warn("Connection rejected (limit reached): " + client_ip);
                 socket.close();
                 continue;
             }
 
-            Log::info("New connection from " + client_ip);
+            Log::info("New connection from " + client_ip +
+                      (trusted ? " (trusted proxy)" : ""));
 
             try {
                 session_threads.emplace_back(handleSession,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -180,6 +180,7 @@ void printUsage(const char* binary) {
               << " [--auth-cache-ttl N] [--auth-api-timeout N]"
               << " [--cert cert.pem] [--key key.pem]"
               << " [--max-connections N] [--max-connections-per-ip N]"
+              << " [--trusted-proxy-hosts HOSTS] [--trusted-proxy-refresh-sec N]"
               << " [--whisper-beam-size N] [--whisper-threads N]"
               << " [--max-concurrent-inference N] [--model-cache-ttl N]"
               << " [--whisper-initial-prompt TEXT] [--session-timeout-sec N] [--shutdown-timeout-sec N]"
@@ -190,6 +191,7 @@ void printUsage(const char* binary) {
     std::cout << "  MODEL_PATH, BIND_ADDRESS, PORT," << std::endl;
     std::cout << "  AUTH_TOKEN, AUTH_API_URL, AUTH_API_SECRET, AUTH_CACHE_TTL, AUTH_API_TIMEOUT," << std::endl;
     std::cout << "  TLS_CERT, TLS_KEY, MAX_CONNECTIONS, MAX_CONNECTIONS_PER_IP," << std::endl;
+    std::cout << "  TRUSTED_PROXY_HOSTS, TRUSTED_PROXY_REFRESH_SEC," << std::endl;
     std::cout << "  WHISPER_BEAM_SIZE, WHISPER_THREADS, MAX_CONCURRENT_INFERENCE," << std::endl;
     std::cout << "  MODEL_CACHE_TTL, WHISPER_INITIAL_PROMPT, SESSION_TIMEOUT_SEC, SHUTDOWN_TIMEOUT_SEC," << std::endl;
     std::cout << "  WHISPER_TEMPERATURE, WHISPER_TEMPERATURE_INC," << std::endl;

--- a/src/server/ConnectionLimiter.cpp
+++ b/src/server/ConnectionLimiter.cpp
@@ -3,15 +3,15 @@
 ConnectionLimiter::ConnectionLimiter(size_t max_total, size_t max_per_ip)
     : max_total_(max_total), max_per_ip_(max_per_ip), total_(0) {}
 
-bool ConnectionLimiter::tryAcquire(const std::string& ip) {
+bool ConnectionLimiter::tryAcquire(const std::string& ip, bool trusted) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (total_ >= max_total_) {
-        return false;
+        return false;  // global cap ALWAYS applies, even for trusted proxies
     }
 
     size_t& count = per_ip_[ip];
-    if (count >= max_per_ip_) {
-        return false;
+    if (!trusted && count >= max_per_ip_) {
+        return false;  // per-IP cap only for untrusted clients
     }
 
     ++count;

--- a/src/server/ConnectionLimiter.h
+++ b/src/server/ConnectionLimiter.h
@@ -7,7 +7,7 @@ class ConnectionLimiter {
 public:
     ConnectionLimiter(size_t max_total, size_t max_per_ip);
 
-    bool tryAcquire(const std::string& ip);
+    bool tryAcquire(const std::string& ip, bool trusted = false);
     void release(const std::string& ip);
 
     std::string getMetrics() const;

--- a/src/server/HandshakeWatchdog.h
+++ b/src/server/HandshakeWatchdog.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "server/SocketUtil.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+// jota-transcriber#68 covered a session that had already completed its
+// WebSocket handshake and then went idle forever. That fix (the flushLoop
+// watchdog in StreamingSession) doesn't cover an earlier, wider gap: the
+// ConnectionGuard slot in handleSession() is acquired *before* the TLS
+// handshake and the initial HTTP upgrade request are read, and neither has
+// any timeout at all — a client that opens a TCP connection and sends
+// nothing (or trickles data arbitrarily slowly) holds that slot forever.
+//
+// HandshakeWatchdog closes that gap with the same primitive: a short-lived,
+// per-connection background thread that force-shuts the socket down if
+// disarm() isn't called before the deadline. Safe to disarm() multiple
+// times, including after it has already fired.
+class HandshakeWatchdog {
+public:
+    template <class NativeHandle>
+    HandshakeWatchdog(NativeHandle fd, int timeout_sec)
+        : armed_(true) {
+        thread_ = std::thread([this, fd, timeout_sec]() {
+            std::unique_lock<std::mutex> lk(mutex_);
+            cv_.wait_for(lk, std::chrono::seconds(timeout_sec), [this] { return !armed_; });
+            if (armed_) {
+                armed_ = false;
+                forceSocketShutdown(fd);
+            }
+        });
+    }
+
+    ~HandshakeWatchdog() {
+        disarm();
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    HandshakeWatchdog(const HandshakeWatchdog&) = delete;
+    HandshakeWatchdog& operator=(const HandshakeWatchdog&) = delete;
+
+    void disarm() {
+        {
+            std::lock_guard<std::mutex> lk(mutex_);
+            armed_ = false;
+        }
+        cv_.notify_one();
+    }
+
+private:
+    bool armed_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::thread thread_;
+};

--- a/src/server/ServerConfig.h
+++ b/src/server/ServerConfig.h
@@ -13,6 +13,7 @@ struct ServerConfig {
     std::string trusted_proxy_hosts;    // CSV hostnames exempt from per-IP limit (empty = off)
     int trusted_proxy_refresh_sec = 30; // DNS re-resolution interval for trusted hosts
     int session_timeout_sec = 30;       // seconds before disconnecting idle sessions
+    int handshake_timeout_sec = 10;     // seconds to complete TLS/HTTP-upgrade handshake before forcing the socket closed
 
     // Auth
     std::string auth_token;             // static token (simple deployments, no API needed)

--- a/src/server/ServerConfig.h
+++ b/src/server/ServerConfig.h
@@ -9,6 +9,8 @@ struct ServerConfig {
     std::string key_path;
     size_t max_connections = 8;
     size_t max_connections_per_ip = 2;
+    std::string trusted_proxy_hosts;    // CSV hostnames exempt from per-IP limit (empty = off)
+    int trusted_proxy_refresh_sec = 30; // DNS re-resolution interval for trusted hosts
     int session_timeout_sec = 30;       // seconds before disconnecting idle sessions
 
     // Auth

--- a/src/server/SocketUtil.h
+++ b/src/server/SocketUtil.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#if defined(_WIN32)
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#endif
+
+// Forcibly interrupts a thread blocked in a synchronous read/write on this
+// socket, from a *different* thread, by shutting it down at the protocol
+// level in both directions. A pending blocking read returns 0 (EOF); a
+// pending/future write fails with EPIPE/ECONNRESET.
+//
+// Deliberately does NOT close() the descriptor: close() from a thread that
+// doesn't own the socket object races with fd reuse (the number can be
+// handed to a brand-new, unrelated connection before the blocked thread
+// notices). shutdown() carries no such risk — the fd stays valid until the
+// owning thread's normal cleanup path closes it after observing the error.
+//
+// This is the fix for jota-transcriber#68: SO_RCVTIMEO set on the native
+// handle does not reliably interrupt a synchronous Boost.Asio/Beast read
+// (Asio treats the resulting EWOULDBLOCK as a spurious wakeup and retries
+// instead of propagating a timeout).
+#if defined(_WIN32)
+inline void forceSocketShutdown(SOCKET fd) {
+    ::shutdown(fd, SD_BOTH);
+}
+#else
+inline void forceSocketShutdown(int fd) {
+    ::shutdown(fd, SHUT_RDWR);
+}
+#endif

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -23,6 +23,7 @@
 #include "log/Log.h"
 #include "utils/HallucinationGuard.h"
 #include "whisper/InferenceLimiter.h"
+#include "server/SocketUtil.h"
 
 namespace beast = boost::beast;
 namespace websocket = beast::websocket;
@@ -101,28 +102,25 @@ public:
     }
 
     void shutdown() override {
-        // Triggered asynchronously by signal handler. We try to close cleanly if we can.
+        // Triggered asynchronously by signal handler (SessionTracker::shutdownAll()),
+        // from a thread other than the one possibly blocked in ws_.read() below.
+        // .cancel() alone only cancels pending *async* operations — it does not
+        // reliably interrupt a synchronous read already in progress (same gotcha
+        // as the idle-watchdog in flushLoop(), see jota-transcriber#68). Force-shut
+        // the native socket too, so a blocked read unblocks with an error either way.
         boost::system::error_code ec;
         beast::get_lowest_layer(ws_).cancel(ec);
+        forceSocketShutdown(beast::get_lowest_layer(ws_).native_handle());
     }
 
     template<class Req>
     void run(const Req& req) {
         try {
-            if (session_timeout_sec_ > 0) {
-                // Set native socket receive timeout to drop idle/zombie connections
-                auto native_socket = beast::get_lowest_layer(ws_).native_handle();
-#if defined(_WIN32)
-                DWORD timeout = session_timeout_sec_ * 1000;
-                setsockopt(native_socket, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout));
-#else
-                struct timeval tv;
-                tv.tv_sec = session_timeout_sec_;
-                tv.tv_usec = 0;
-                setsockopt(native_socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-#endif
-            }
-
+            // Idle timeout is enforced by flushLoop()'s watchdog (see below), not by
+            // SO_RCVTIMEO: that socket option does not reliably interrupt a
+            // synchronous Boost.Asio/Beast read (jota-transcriber#68) — Asio treats
+            // the resulting EWOULDBLOCK as a spurious wakeup and retries the
+            // blocking read instead of propagating a timeout.
             ws_.accept(req);
             Log::info("WebSocket handshake accepted", session_id_);
 
@@ -531,6 +529,7 @@ private:
     std::mutex flush_cv_mutex_;
     std::condition_variable flush_cv_;
     std::chrono::steady_clock::time_point last_audio_time_;
+    bool idle_shutdown_triggered_ = false;
 
     // Sliding window logic
     std::string full_transcription_;     // filtered (hallucinations discarded)
@@ -567,6 +566,26 @@ private:
             std::unique_lock<std::mutex> lock(state_mutex_, std::defer_lock);
             if (!lock.try_lock()) {
                 continue;
+            }
+
+            // Idle watchdog (jota-transcriber#68): a client that goes quiet without
+            // ever sending a WS close frame — network partition, crash, or just
+            // abandoning the connection — must not hang ws_.read() on the main
+            // thread forever, since that leaks this session's ConnectionLimiter
+            // slot indefinitely. SO_RCVTIMEO on the native socket doesn't reliably
+            // interrupt that synchronous read, so force it from here instead:
+            // this thread runs regardless of configured_/engine_ state, so an
+            // unconfigured session (never sent "config") is covered too.
+            if (session_timeout_sec_ > 0 && !idle_shutdown_triggered_) {
+                auto idle_s = std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::steady_clock::now() - last_audio_time_).count();
+                if (idle_s >= session_timeout_sec_) {
+                    idle_shutdown_triggered_ = true;
+                    Log::warn("Idle timeout (" + std::to_string(idle_s) + "s >= " +
+                              std::to_string(session_timeout_sec_) +
+                              "s), forcing socket shutdown", session_id_);
+                    forceSocketShutdown(beast::get_lowest_layer(ws_).native_handle());
+                }
             }
 
             if (!configured_ || !engine_) continue;

--- a/src/server/TrustedProxyResolver.cpp
+++ b/src/server/TrustedProxyResolver.cpp
@@ -41,20 +41,24 @@ bool TrustedProxyResolver::isTrusted(const std::string& ip) {
     bool stale = !ever_resolved_ ||
                  (now - last_resolve_ >= std::chrono::seconds(refresh_sec_));
     if (stale) {
-        std::unordered_set<std::string> fresh;
         for (const auto& host : hosts_) {
+            std::unordered_set<std::string> fresh;
             for (auto& resolved : resolver_(host)) {
                 fresh.insert(resolved);
             }
+            if (!fresh.empty()) {
+                per_host_ips_[host] = std::move(fresh);
+                ever_resolved_ = true;
+            }
+            // else: keep this host's last known-good set (fail-closed if
+            // this host has never resolved). Other hosts are unaffected.
         }
-        if (!fresh.empty()) {
-            trusted_ips_ = std::move(fresh);
-            ever_resolved_ = true;
-        }
-        // else: keep last known-good set (fail-closed if never resolved).
         last_resolve_ = now;  // bound retry cost to once per refresh window
     }
-    return trusted_ips_.count(ip) > 0;
+    for (const auto& [host, ips] : per_host_ips_) {
+        if (ips.count(ip) > 0) return true;
+    }
+    return false;
 }
 
 // static

--- a/src/server/TrustedProxyResolver.cpp
+++ b/src/server/TrustedProxyResolver.cpp
@@ -17,10 +17,8 @@ std::string trim(const std::string& s) {
 }  // namespace
 
 TrustedProxyResolver::TrustedProxyResolver(const std::string& comma_separated_hosts,
-                                           int refresh_sec,
                                            ResolveFn resolver)
-    : refresh_sec_(refresh_sec),
-      resolver_(resolver ? std::move(resolver) : &TrustedProxyResolver::defaultResolver) {
+    : resolver_(resolver ? std::move(resolver) : &TrustedProxyResolver::defaultResolver) {
     std::stringstream ss(comma_separated_hosts);
     std::string item;
     while (std::getline(ss, item, ',')) {
@@ -33,28 +31,37 @@ bool TrustedProxyResolver::enabled() const {
     return !hosts_.empty();
 }
 
-bool TrustedProxyResolver::isTrusted(const std::string& ip) {
+void TrustedProxyResolver::refresh() {
+    if (hosts_.empty()) return;
+
+    // Resolve every host WITHOUT holding mutex_ — getaddrinfo can block for
+    // a long time during a DNS outage, and isTrusted() must never wait on
+    // it. Collect results locally first.
+    std::unordered_map<std::string, std::unordered_set<std::string>> resolved;
+    for (const auto& host : hosts_) {
+        std::unordered_set<std::string> fresh;
+        for (auto& ip : resolver_(host)) {
+            fresh.insert(ip);
+        }
+        if (!fresh.empty()) {
+            resolved[host] = std::move(fresh);
+        }
+        // else: this host failed to resolve this round. It's simply absent
+        // from `resolved`, so the merge below leaves per_host_ips_[host]
+        // untouched — fail-closed if it never resolved before, otherwise
+        // keeps the last known-good set for that host.
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& [host, ips] : resolved) {
+        per_host_ips_[host] = std::move(ips);
+    }
+}
+
+bool TrustedProxyResolver::isTrusted(const std::string& ip) const {
     if (hosts_.empty()) return false;
 
     std::lock_guard<std::mutex> lock(mutex_);
-    auto now = std::chrono::steady_clock::now();
-    bool stale = !ever_resolved_ ||
-                 (now - last_resolve_ >= std::chrono::seconds(refresh_sec_));
-    if (stale) {
-        for (const auto& host : hosts_) {
-            std::unordered_set<std::string> fresh;
-            for (auto& resolved : resolver_(host)) {
-                fresh.insert(resolved);
-            }
-            if (!fresh.empty()) {
-                per_host_ips_[host] = std::move(fresh);
-                ever_resolved_ = true;
-            }
-            // else: keep this host's last known-good set (fail-closed if
-            // this host has never resolved). Other hosts are unaffected.
-        }
-        last_resolve_ = now;  // bound retry cost to once per refresh window
-    }
     for (const auto& [_, ips] : per_host_ips_) {
         if (ips.count(ip) > 0) return true;
     }

--- a/src/server/TrustedProxyResolver.cpp
+++ b/src/server/TrustedProxyResolver.cpp
@@ -55,7 +55,7 @@ bool TrustedProxyResolver::isTrusted(const std::string& ip) {
         }
         last_resolve_ = now;  // bound retry cost to once per refresh window
     }
-    for (const auto& [host, ips] : per_host_ips_) {
+    for (const auto& [_, ips] : per_host_ips_) {
         if (ips.count(ip) > 0) return true;
     }
     return false;

--- a/src/server/TrustedProxyResolver.cpp
+++ b/src/server/TrustedProxyResolver.cpp
@@ -1,0 +1,84 @@
+#include "TrustedProxyResolver.h"
+
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <sstream>
+#include <cctype>
+
+namespace {
+std::string trim(const std::string& s) {
+    size_t a = 0, b = s.size();
+    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
+    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) --b;
+    return s.substr(a, b - a);
+}
+}  // namespace
+
+TrustedProxyResolver::TrustedProxyResolver(const std::string& comma_separated_hosts,
+                                           int refresh_sec,
+                                           ResolveFn resolver)
+    : refresh_sec_(refresh_sec),
+      resolver_(resolver ? std::move(resolver) : &TrustedProxyResolver::defaultResolver) {
+    std::stringstream ss(comma_separated_hosts);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        std::string h = trim(item);
+        if (!h.empty()) hosts_.push_back(h);
+    }
+}
+
+bool TrustedProxyResolver::enabled() const {
+    return !hosts_.empty();
+}
+
+bool TrustedProxyResolver::isTrusted(const std::string& ip) {
+    if (hosts_.empty()) return false;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto now = std::chrono::steady_clock::now();
+    bool stale = !ever_resolved_ ||
+                 (now - last_resolve_ >= std::chrono::seconds(refresh_sec_));
+    if (stale) {
+        std::unordered_set<std::string> fresh;
+        for (const auto& host : hosts_) {
+            for (auto& resolved : resolver_(host)) {
+                fresh.insert(resolved);
+            }
+        }
+        if (!fresh.empty()) {
+            trusted_ips_ = std::move(fresh);
+            ever_resolved_ = true;
+        }
+        // else: keep last known-good set (fail-closed if never resolved).
+        last_resolve_ = now;  // bound retry cost to once per refresh window
+    }
+    return trusted_ips_.count(ip) > 0;
+}
+
+// static
+std::vector<std::string> TrustedProxyResolver::defaultResolver(const std::string& host) {
+    std::vector<std::string> out;
+    struct addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;      // IPv4 + IPv6
+    hints.ai_socktype = SOCK_STREAM;
+    struct addrinfo* res = nullptr;
+    if (getaddrinfo(host.c_str(), nullptr, &hints, &res) != 0) {
+        return out;  // empty on failure
+    }
+    for (auto* p = res; p != nullptr; p = p->ai_next) {
+        char buf[INET6_ADDRSTRLEN] = {0};
+        void* addr = nullptr;
+        if (p->ai_family == AF_INET) {
+            addr = &reinterpret_cast<struct sockaddr_in*>(p->ai_addr)->sin_addr;
+        } else if (p->ai_family == AF_INET6) {
+            addr = &reinterpret_cast<struct sockaddr_in6*>(p->ai_addr)->sin6_addr;
+        }
+        if (addr && inet_ntop(p->ai_family, addr, buf, sizeof(buf))) {
+            out.emplace_back(buf);
+        }
+    }
+    freeaddrinfo(res);
+    return out;
+}

--- a/src/server/TrustedProxyResolver.h
+++ b/src/server/TrustedProxyResolver.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <unordered_set>
+#include <functional>
+#include <mutex>
+#include <chrono>
+
+// Resolves operator-configured hostnames to IPs on a refresh interval and
+// answers whether a given IP belongs to a trusted proxy. Deploy-agnostic:
+// works with k8s CoreDNS Service FQDNs and with docker-compose / localhost.
+//
+// Empty host list => enabled() == false and isTrusted() always false (no-op).
+// Fail-closed: if a hostname never resolves, nobody is trusted. On a later
+// resolution failure the last known-good IP set is kept.
+//
+// isTrusted() is called only from the single-threaded accept loop; the mutex
+// is defensive and also lets tests drive it safely.
+class TrustedProxyResolver {
+public:
+    using ResolveFn = std::function<std::vector<std::string>(const std::string&)>;
+
+    // resolver defaults to defaultResolver() when empty.
+    TrustedProxyResolver(const std::string& comma_separated_hosts,
+                         int refresh_sec,
+                         ResolveFn resolver = {});
+
+    bool isTrusted(const std::string& ip);
+    bool enabled() const;
+
+    // getaddrinfo-backed resolver (IPv4 + IPv6). Returns empty on failure.
+    static std::vector<std::string> defaultResolver(const std::string& host);
+
+private:
+    std::vector<std::string> hosts_;
+    int refresh_sec_;
+    ResolveFn resolver_;
+
+    std::mutex mutex_;
+    std::unordered_set<std::string> trusted_ips_;
+    std::chrono::steady_clock::time_point last_resolve_{};
+    bool ever_resolved_ = false;
+};

--- a/src/server/TrustedProxyResolver.h
+++ b/src/server/TrustedProxyResolver.h
@@ -15,6 +15,12 @@
 // Fail-closed: if a hostname never resolves, nobody is trusted. On a later
 // resolution failure the last known-good IP set is kept.
 //
+// Dual-stack caveat: if the server binds to "::", Boost.Asio reports IPv4
+// peers as "::ffff:a.b.c.d", but defaultResolver() returns bare IPv4
+// strings (e.g. "a.b.c.d") from AF_INET records. An IPv4 trusted-proxy
+// hostname then won't match and silently fails closed (not a security
+// hole, but worth knowing when troubleshooting).
+//
 // isTrusted() is called only from the single-threaded accept loop; the mutex
 // is defensive and also lets tests drive it safely.
 class TrustedProxyResolver {

--- a/src/server/TrustedProxyResolver.h
+++ b/src/server/TrustedProxyResolver.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
+#include <unordered_map>
 #include <functional>
 #include <mutex>
 #include <chrono>
@@ -37,7 +38,7 @@ private:
     ResolveFn resolver_;
 
     std::mutex mutex_;
-    std::unordered_set<std::string> trusted_ips_;
+    std::unordered_map<std::string, std::unordered_set<std::string>> per_host_ips_;
     std::chrono::steady_clock::time_point last_resolve_{};
     bool ever_resolved_ = false;
 };

--- a/src/server/TrustedProxyResolver.h
+++ b/src/server/TrustedProxyResolver.h
@@ -5,11 +5,10 @@
 #include <unordered_map>
 #include <functional>
 #include <mutex>
-#include <chrono>
 
-// Resolves operator-configured hostnames to IPs on a refresh interval and
-// answers whether a given IP belongs to a trusted proxy. Deploy-agnostic:
-// works with k8s CoreDNS Service FQDNs and with docker-compose / localhost.
+// Resolves operator-configured hostnames to IPs and answers whether a given
+// IP belongs to a trusted proxy. Deploy-agnostic: works with k8s CoreDNS
+// Service FQDNs and with docker-compose / localhost.
 //
 // Empty host list => enabled() == false and isTrusted() always false (no-op).
 // Fail-closed: if a hostname never resolves, nobody is trusted. On a later
@@ -21,18 +20,30 @@
 // hostname then won't match and silently fails closed (not a security
 // hole, but worth knowing when troubleshooting).
 //
-// isTrusted() is called only from the single-threaded accept loop; the mutex
-// is defensive and also lets tests drive it safely.
+// Concurrency model: refresh() does the (potentially slow) DNS I/O and does
+// NOT hold `mutex_` while calling `resolver_` — only while merging the
+// freshly resolved data into `per_host_ips_`. isTrusted() is a pure,
+// non-blocking cache read (lock + set lookup) and is safe to call
+// concurrently with refresh() from a different thread. In production,
+// isTrusted() runs on the accept-loop thread while a separate background
+// thread calls refresh() on a timer (see server.cpp) — this class does not
+// own or manage that thread itself.
 class TrustedProxyResolver {
 public:
     using ResolveFn = std::function<std::vector<std::string>(const std::string&)>;
 
     // resolver defaults to defaultResolver() when empty.
     TrustedProxyResolver(const std::string& comma_separated_hosts,
-                         int refresh_sec,
                          ResolveFn resolver = {});
 
-    bool isTrusted(const std::string& ip);
+    // Re-resolves every configured host and merges successes into the
+    // cached set. Safe to call from any thread; never blocks isTrusted().
+    void refresh();
+
+    // Pure cache read: true if `ip` belongs to any trusted host's last
+    // successfully resolved IP set. Never does I/O, never blocks.
+    bool isTrusted(const std::string& ip) const;
+
     bool enabled() const;
 
     // getaddrinfo-backed resolver (IPv4 + IPv6). Returns empty on failure.
@@ -40,11 +51,8 @@ public:
 
 private:
     std::vector<std::string> hosts_;
-    int refresh_sec_;
     ResolveFn resolver_;
 
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     std::unordered_map<std::string, std::unordered_set<std::string>> per_host_ips_;
-    std::chrono::steady_clock::time_point last_resolve_{};
-    bool ever_resolved_ = false;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(unit_tests
     unit/test_audio_pipeline.cpp
     unit/test_inference_limiter.cpp
     unit/test_connection_limiter.cpp
+    unit/test_trusted_proxy_resolver.cpp
     unit/test_session_tracker.cpp
     unit/test_model_cache.cpp
     unit/test_streaming_whisper_engine.cpp
@@ -16,6 +17,7 @@ add_executable(unit_tests
     # Fuentes del servidor que no tienen dependencias de Boost/OpenSSL
     ${CMAKE_SOURCE_DIR}/src/audio/AudioDecoder.cpp
     ${CMAKE_SOURCE_DIR}/src/server/ConnectionLimiter.cpp
+    ${CMAKE_SOURCE_DIR}/src/server/TrustedProxyResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/server/ConnectionGuard.cpp
     ${CMAKE_SOURCE_DIR}/src/server/AuthManager.cpp
     ${CMAKE_SOURCE_DIR}/src/server/MultipartParser.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(unit_tests
     unit/test_multipart_parser.cpp
     unit/test_http_router.cpp
     unit/test_handle_transcribe.cpp
+    unit/test_socket_util.cpp
+    unit/test_handshake_watchdog.cpp
     # Fuentes del servidor que no tienen dependencias de Boost/OpenSSL
     ${CMAKE_SOURCE_DIR}/src/audio/AudioDecoder.cpp
     ${CMAKE_SOURCE_DIR}/src/server/ConnectionLimiter.cpp

--- a/tests/unit/test_connection_limiter.cpp
+++ b/tests/unit/test_connection_limiter.cpp
@@ -55,6 +55,32 @@ TEST(ConnectionLimiter, MetricsContainExpectedKey) {
     EXPECT_NE(m.find("transcription_active_connections"), std::string::npos);
 }
 
+TEST(ConnectionLimiter, TrustedIpBypassesPerIpLimit) {
+    auto lim = std::make_shared<ConnectionLimiter>(10, 1); // per-IP cap 1
+    EXPECT_TRUE(lim->tryAcquire("1.1.1.1", true));
+    EXPECT_TRUE(lim->tryAcquire("1.1.1.1", true));  // would fail if not trusted
+    EXPECT_TRUE(lim->tryAcquire("1.1.1.1", true));
+    lim->release("1.1.1.1");
+    lim->release("1.1.1.1");
+    lim->release("1.1.1.1");
+}
+
+TEST(ConnectionLimiter, TrustedIpStillBoundedByGlobalLimit) {
+    auto lim = std::make_shared<ConnectionLimiter>(2, 1); // global cap 2
+    EXPECT_TRUE(lim->tryAcquire("1.1.1.1", true));
+    EXPECT_TRUE(lim->tryAcquire("1.1.1.1", true));
+    EXPECT_FALSE(lim->tryAcquire("1.1.1.1", true)); // global cap reached
+    lim->release("1.1.1.1");
+    lim->release("1.1.1.1");
+}
+
+TEST(ConnectionLimiter, UntrustedDefaultStillLimitedPerIp) {
+    auto lim = std::make_shared<ConnectionLimiter>(10, 1);
+    EXPECT_TRUE(lim->tryAcquire("1.1.1.1"));            // default trusted=false
+    EXPECT_FALSE(lim->tryAcquire("1.1.1.1"));           // per-IP cap 1 still applies
+    lim->release("1.1.1.1");
+}
+
 // ─── ConnectionGuard ─────────────────────────────────────────────────────────
 
 TEST(ConnectionGuard, ReleasesSlotOnDestruction) {

--- a/tests/unit/test_handshake_watchdog.cpp
+++ b/tests/unit/test_handshake_watchdog.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+#include "server/HandshakeWatchdog.h"
+
+#include <sys/socket.h>
+#include <unistd.h>
+#include <thread>
+#include <chrono>
+
+// A raw TCP connection that completes the 3-way handshake but then sends
+// nothing (or trickles data arbitrarily slowly) currently has zero timeout
+// protection in handleSession(): the ConnectionGuard slot is acquired before
+// any timeout exists, and the SSL handshake + initial HTTP read run fully
+// unprotected. HandshakeWatchdog closes that gap: armed with a native socket
+// handle and a deadline, it force-shuts the socket down if disarm() isn't
+// called first.
+TEST(HandshakeWatchdog, ForceClosesSocketIfNotDisarmedBeforeTimeout) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+    HandshakeWatchdog watchdog(fds[0], /*timeout_sec=*/1);
+
+    // Block on the peer end waiting for the watched fd to do *anything*.
+    // Nobody ever writes — the only way this unblocks is the watchdog
+    // force-shutting fds[0] down once its 1s deadline elapses.
+    char buf[16];
+    auto start = std::chrono::steady_clock::now();
+    ssize_t n = read(fds[1], buf, sizeof(buf));
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_EQ(0, n) << "expected EOF from the watchdog forcing shutdown, got errno=" << errno;
+    EXPECT_LT(elapsed, std::chrono::seconds(3))
+        << "watchdog fired far later than its configured 1s deadline";
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(HandshakeWatchdog, DisarmPreventsForceClose) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+    {
+        HandshakeWatchdog watchdog(fds[0], /*timeout_sec=*/1);
+        watchdog.disarm();
+        // destructor runs here — must be a harmless no-op on an
+        // already-disarmed watchdog.
+    }
+
+    // Wait past the original deadline to prove nothing fires late.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    // The socket must still be fully alive: write on the watched fd, read
+    // it back on the peer.
+    const char msg = 'x';
+    ASSERT_EQ(1, write(fds[0], &msg, 1));
+    char buf[1] = {0};
+    ASSERT_EQ(1, read(fds[1], buf, 1));
+    EXPECT_EQ('x', buf[0]);
+
+    close(fds[0]);
+    close(fds[1]);
+}

--- a/tests/unit/test_socket_util.cpp
+++ b/tests/unit/test_socket_util.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include "server/SocketUtil.h"
+
+#include <sys/socket.h>
+#include <unistd.h>
+#include <thread>
+#include <atomic>
+#include <chrono>
+
+// forceSocketShutdown() must reliably unblock a thread parked in a
+// synchronous, blocking read() on the socket — this is the core primitive
+// the StreamingSession idle-watchdog and HandshakeWatchdog both depend on
+// (jota-transcriber#68: SO_RCVTIMEO alone does not reliably interrupt a
+// blocking read on a Boost.Asio-managed socket).
+TEST(SocketUtil, ForceSocketShutdownUnblocksPendingRead) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+    std::atomic<bool> read_returned{false};
+    std::atomic<ssize_t> read_result{-2};
+
+    std::thread reader([&]() {
+        char buf[16];
+        ssize_t n = read(fds[0], buf, sizeof(buf));
+        read_result = n;
+        read_returned = true;
+    });
+
+    // Give the reader thread time to actually block in read() before we shut it down.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ASSERT_FALSE(read_returned.load()) << "reader returned before shutdown — test setup is wrong";
+
+    forceSocketShutdown(fds[0]);
+
+    reader.join();
+    EXPECT_TRUE(read_returned.load());
+    EXPECT_EQ(0, read_result.load()) << "expected EOF (0) from a shut-down read, not an error or data";
+
+    close(fds[0]);
+    close(fds[1]);
+}

--- a/tests/unit/test_streaming_session.cpp
+++ b/tests/unit/test_streaming_session.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <atomic>
 #include <cstring>
+#include <future>
 
 namespace beast = boost::beast;
 namespace http = beast::http;
@@ -97,7 +98,7 @@ protected:
         }
     }
 
-    uint16_t startServer(bool require_auth = false) {
+    uint16_t startServer(bool require_auth = false, int session_timeout_sec = 30) {
         tcp::endpoint endpoint(net::ip::make_address("127.0.0.1"), 0);
         acceptor_ = std::make_unique<tcp::acceptor>(ioc_, endpoint);
         uint16_t port = acceptor_->local_endpoint().port();
@@ -109,18 +110,18 @@ protected:
         }
         auto auth_manager = std::make_shared<AuthManager>(auth_cfg);
 
-        doAccept(auth_manager);
+        doAccept(auth_manager, session_timeout_sec);
 
         server_thread_ = std::thread([this]() { ioc_.run(); });
         return port;
     }
 
-    void doAccept(std::shared_ptr<AuthManager> auth_manager) {
+    void doAccept(std::shared_ptr<AuthManager> auth_manager, int session_timeout_sec = 30) {
         acceptor_->async_accept(
-            [this, auth_manager](boost::system::error_code ec, tcp::socket socket) {
+            [this, auth_manager, session_timeout_sec](boost::system::error_code ec, tcp::socket socket) {
                 if (!ec) {
                     session_threads_.emplace_back(
-                        [this, s = std::move(socket), auth_manager]() mutable {
+                        [this, s = std::move(socket), auth_manager, session_timeout_sec]() mutable {
                             try {
                                 boost::beast::flat_buffer buffer;
                                 boost::beast::http::request<boost::beast::http::string_body> req;
@@ -133,18 +134,27 @@ protected:
                                     std::move(ws),
                                     model_path,
                                     auth_manager,
-                                    5, 4, "", 30, 0.2f, 0.2f, 0.3f, -1.0f
+                                    5, 4, "", session_timeout_sec, 0.2f, 0.2f, 0.3f, -1.0f
                                 );
                                 session->run(req);
                             } catch (...) {}
                         });
-                    doAccept(auth_manager);
+                    doAccept(auth_manager, session_timeout_sec);
                 }
             });
     }
 
     WsTestClient connect(uint16_t port) {
         return WsTestClient(client_ioc_, port);
+    }
+
+    // WsTestClient is neither copyable nor movable (its destructor's
+    // is_open()/close() aren't safe to run against a moved-from Beast
+    // stream). Construct it in place inside the shared_ptr — no
+    // intermediate moved-from object is ever created — for tests that
+    // need to hand the client to a background thread.
+    std::shared_ptr<WsTestClient> connectShared(uint16_t port) {
+        return std::make_shared<WsTestClient>(client_ioc_, port);
     }
 
 private:
@@ -348,6 +358,49 @@ TEST_F(StreamingSessionTest, DoubleConfig) {
     auto msg2 = client.recvJson();
     EXPECT_EQ(msg2["type"], "ready");
     EXPECT_EQ(msg2["config"]["language"], "en");
+}
+
+// jota-transcriber#68: a client that goes idle without ever sending a WS
+// close frame (network partition, crash, or simply abandoning the
+// connection — not necessarily a client bug) must not hang the session's
+// ws_.read() forever, since that leaks its ConnectionLimiter slot
+// indefinitely. Before the fix, SO_RCVTIMEO alone does not reliably
+// interrupt a synchronous Boost.Asio/Beast read, so this reproduces the
+// incident directly: configure a short session_timeout_sec, complete the
+// handshake, then go silent — the server must force-close the socket
+// within session_timeout_sec + a small margin.
+TEST_F(StreamingSessionTest, IdleSessionForceClosedWithinTimeout) {
+    auto port = startServer(false, /*session_timeout_sec=*/1);
+    auto client = connectShared(port);
+
+    client->sendJson({{"type", "config"}, {"language", "es"}});
+    auto ready = client->recvJson();
+    ASSERT_EQ(ready["type"], "ready");
+
+    // From here on the client goes idle and never closes cleanly. The
+    // read below blocks until the server does *something* — either a
+    // graceful close (not expected here) or the underlying socket being
+    // shut down out from under it, which surfaces as an error/EOF.
+    // Captured by shared_ptr and detached: if the fix is broken this
+    // thread blocks forever, but it must not dangle a reference into a
+    // destroyed test fixture or hang the test function itself.
+    auto done = std::make_shared<std::promise<void>>();
+    auto done_future = done->get_future();
+    std::thread([client, done]() {
+        try {
+            client->recvJson();
+        } catch (...) {
+            // Any error/EOF counts: we're proving the client's read
+            // unblocked, not asserting which specific error Beast
+            // surfaces for a peer that vanished without a close frame.
+        }
+        done->set_value();
+    }).detach();
+
+    auto status = done_future.wait_for(std::chrono::seconds(5));
+    EXPECT_EQ(std::future_status::ready, status)
+        << "server never force-closed the idle session — the ConnectionLimiter "
+           "slot would leak forever, exactly as in the jota-transcriber#68 incident";
 }
 
 TEST(MsToSamples16kHzTest, ConvertsMillisecondsToSampleCount) {

--- a/tests/unit/test_trusted_proxy_resolver.cpp
+++ b/tests/unit/test_trusted_proxy_resolver.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+#include "server/TrustedProxyResolver.h"
+#include <atomic>
+
+TEST(TrustedProxyResolver, EmptyHostsDisabled) {
+    TrustedProxyResolver r("", 30);
+    EXPECT_FALSE(r.enabled());
+    EXPECT_FALSE(r.isTrusted("127.0.0.1"));
+}
+
+TEST(TrustedProxyResolver, ResolvesAndTrustsBothFamilies) {
+    TrustedProxyResolver r("localhost", 30,
+        [](const std::string&) -> std::vector<std::string> {
+            return {"127.0.0.1", "::1"};
+        });
+    EXPECT_TRUE(r.enabled());
+    EXPECT_TRUE(r.isTrusted("127.0.0.1"));
+    EXPECT_TRUE(r.isTrusted("::1"));
+    EXPECT_FALSE(r.isTrusted("8.8.8.8"));
+}
+
+TEST(TrustedProxyResolver, FailClosedWhenNeverResolved) {
+    TrustedProxyResolver r("gw", 30,
+        [](const std::string&) -> std::vector<std::string> { return {}; });
+    EXPECT_TRUE(r.enabled());          // configured...
+    EXPECT_FALSE(r.isTrusted("10.0.0.1")); // ...but nothing trusted (fail-closed)
+}
+
+TEST(TrustedProxyResolver, CachesWithinTtl) {
+    std::atomic<int> calls{0};
+    TrustedProxyResolver r("gw", 1000,
+        [&calls](const std::string&) -> std::vector<std::string> {
+            ++calls;
+            return {"10.0.0.1"};
+        });
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    EXPECT_EQ(calls.load(), 1); // resolved once, cached within TTL
+}
+
+TEST(TrustedProxyResolver, ReresolvesAfterTtl) {
+    std::atomic<int> calls{0};
+    TrustedProxyResolver r("gw", 0, // 0s => always stale
+        [&calls](const std::string&) -> std::vector<std::string> {
+            ++calls;
+            return {"10.0.0.1"};
+        });
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    EXPECT_EQ(calls.load(), 2); // re-resolved each call
+}
+
+TEST(TrustedProxyResolver, KeepsLastGoodOnResolutionFailure) {
+    std::atomic<int> calls{0};
+    TrustedProxyResolver r("gw", 0, // always stale
+        [&calls](const std::string&) -> std::vector<std::string> {
+            // First call succeeds, later calls fail (empty).
+            return (++calls == 1) ? std::vector<std::string>{"10.0.0.1"}
+                                  : std::vector<std::string>{};
+        });
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));   // call 1: good set stored
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));   // call 2: failure -> keep old set
+}

--- a/tests/unit/test_trusted_proxy_resolver.cpp
+++ b/tests/unit/test_trusted_proxy_resolver.cpp
@@ -2,72 +2,87 @@
 #include "server/TrustedProxyResolver.h"
 #include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 
 TEST(TrustedProxyResolver, EmptyHostsDisabled) {
-    TrustedProxyResolver r("", 30);
+    TrustedProxyResolver r("");
     EXPECT_FALSE(r.enabled());
     EXPECT_FALSE(r.isTrusted("127.0.0.1"));
 }
 
 TEST(TrustedProxyResolver, ResolvesAndTrustsBothFamilies) {
-    TrustedProxyResolver r("localhost", 30,
+    TrustedProxyResolver r("localhost",
         [](const std::string&) -> std::vector<std::string> {
             return {"127.0.0.1", "::1"};
         });
     EXPECT_TRUE(r.enabled());
+    r.refresh();
     EXPECT_TRUE(r.isTrusted("127.0.0.1"));
     EXPECT_TRUE(r.isTrusted("::1"));
     EXPECT_FALSE(r.isTrusted("8.8.8.8"));
 }
 
 TEST(TrustedProxyResolver, FailClosedWhenNeverResolved) {
-    TrustedProxyResolver r("gw", 30,
+    TrustedProxyResolver r("gw",
         [](const std::string&) -> std::vector<std::string> { return {}; });
-    EXPECT_TRUE(r.enabled());          // configured...
-    EXPECT_FALSE(r.isTrusted("10.0.0.1")); // ...but nothing trusted (fail-closed)
+    EXPECT_TRUE(r.enabled());              // configured...
+    r.refresh();                           // ...but the resolver returns nothing...
+    EXPECT_FALSE(r.isTrusted("10.0.0.1")); // ...so nothing is trusted (fail-closed)
 }
 
-TEST(TrustedProxyResolver, CachesWithinTtl) {
+// Replaces the old CachesWithinTtl test: there is no TTL left in the class,
+// so the thing worth proving is the new contract itself — isTrusted() must
+// never trigger a resolution, no matter how many times it's called.
+TEST(TrustedProxyResolver, IsTrustedDoesNotTriggerResolution) {
     std::atomic<int> calls{0};
-    TrustedProxyResolver r("gw", 1000,
+    TrustedProxyResolver r("gw",
         [&calls](const std::string&) -> std::vector<std::string> {
             ++calls;
             return {"10.0.0.1"};
         });
-    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
-    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
-    EXPECT_EQ(calls.load(), 1); // resolved once, cached within TTL
+    EXPECT_FALSE(r.isTrusted("10.0.0.1"));
+    EXPECT_FALSE(r.isTrusted("10.0.0.1"));
+    EXPECT_FALSE(r.isTrusted("10.0.0.1"));
+    EXPECT_EQ(calls.load(), 0);
 }
 
-TEST(TrustedProxyResolver, ReresolvesAfterTtl) {
+// Replaces the old ReresolvesAfterTtl test: refresh() has no internal TTL or
+// caching of its own — every call re-resolves. Cadence is the caller's job.
+TEST(TrustedProxyResolver, RefreshAlwaysCallsResolver) {
     std::atomic<int> calls{0};
-    TrustedProxyResolver r("gw", 0, // 0s => always stale
+    TrustedProxyResolver r("gw",
         [&calls](const std::string&) -> std::vector<std::string> {
             ++calls;
             return {"10.0.0.1"};
         });
+    r.refresh();
+    r.refresh();
+    EXPECT_EQ(calls.load(), 2);
     EXPECT_TRUE(r.isTrusted("10.0.0.1"));
-    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
-    EXPECT_EQ(calls.load(), 2); // re-resolved each call
 }
 
 TEST(TrustedProxyResolver, KeepsLastGoodOnResolutionFailure) {
     std::atomic<int> calls{0};
-    TrustedProxyResolver r("gw", 0, // always stale
+    TrustedProxyResolver r("gw",
         [&calls](const std::string&) -> std::vector<std::string> {
             // First call succeeds, later calls fail (empty).
             return (++calls == 1) ? std::vector<std::string>{"10.0.0.1"}
                                   : std::vector<std::string>{};
         });
-    EXPECT_TRUE(r.isTrusted("10.0.0.1"));   // call 1: good set stored
-    EXPECT_TRUE(r.isTrusted("10.0.0.1"));   // call 2: failure -> keep old set
+    r.refresh();                          // call 1: good set stored
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    r.refresh();                          // call 2: failure -> keep old set
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
 }
 
 // Regression test: a multi-host CSV list must not let one host's transient
 // resolution failure evict another host's previously-good IPs.
 TEST(TrustedProxyResolver, MultiHostPartialFailureKeepsOtherHostGoodIps) {
     std::atomic<int> hostBCalls{0};
-    TrustedProxyResolver r("hostA,hostB", 0, // always stale
+    TrustedProxyResolver r("hostA,hostB",
         [&hostBCalls](const std::string& host) -> std::vector<std::string> {
             if (host == "hostA") {
                 return {"10.0.0.1"};  // hostA always resolves successfully
@@ -77,13 +92,15 @@ TEST(TrustedProxyResolver, MultiHostPartialFailureKeepsOtherHostGoodIps) {
                                         : std::vector<std::string>{};
         });
 
-    // First call: both hosts resolve successfully -> both IPs trusted.
+    // First refresh: both hosts resolve successfully -> both IPs trusted.
+    r.refresh();
     EXPECT_TRUE(r.isTrusted("10.0.0.1"));
     EXPECT_TRUE(r.isTrusted("10.0.0.2"));
 
-    // Second call: refresh_sec=0 re-triggers resolution; hostB now fails.
-    // hostA's IP must remain trusted, and hostB's previously-good IP must
-    // NOT be evicted just because hostB failed this round.
+    // Second refresh: hostB now fails. hostA's IP must remain trusted, and
+    // hostB's previously-good IP must NOT be evicted just because hostB
+    // failed this round.
+    r.refresh();
     EXPECT_TRUE(r.isTrusted("10.0.0.1"));
     EXPECT_TRUE(r.isTrusted("10.0.0.2"));
 }
@@ -106,13 +123,14 @@ TEST(TrustedProxyResolver, DefaultResolverReturnsEmptyForUnresolvableHost) {
 // Whitespace around hosts and empty segments between commas must be
 // trimmed/dropped so the resolver queries clean hostnames.
 TEST(TrustedProxyResolver, ParsesCsvWithWhitespaceAndEmptySegments) {
-    TrustedProxyResolver r(" hostA , , hostB ", 30,
+    TrustedProxyResolver r(" hostA , , hostB ",
         [](const std::string& host) -> std::vector<std::string> {
             if (host == "hostA") return {"10.0.0.1"};
             if (host == "hostB") return {"10.0.0.2"};
             return {};  // untrimmed host string (e.g. " hostA ") would land here
         });
     EXPECT_TRUE(r.enabled());
+    r.refresh();
     EXPECT_TRUE(r.isTrusted("10.0.0.1"));
     EXPECT_TRUE(r.isTrusted("10.0.0.2"));
 }
@@ -120,7 +138,48 @@ TEST(TrustedProxyResolver, ParsesCsvWithWhitespaceAndEmptySegments) {
 // A CSV string that is only whitespace/commas has no real hosts -> disabled,
 // same as an empty string.
 TEST(TrustedProxyResolver, AllWhitespaceOrEmptySegmentsCsvDisabled) {
-    TrustedProxyResolver r(" , ,  ", 30);
+    TrustedProxyResolver r(" , ,  ");
     EXPECT_FALSE(r.enabled());
     EXPECT_FALSE(r.isTrusted("127.0.0.1"));
+}
+
+// Regression test for #73: refresh() must not hold the internal lock while
+// the resolver is doing its (potentially slow/blocking) I/O — a resolver
+// stuck inside a DNS call must never make isTrusted() block. This test
+// fails against the old implementation (mutex held for the whole resolver_
+// call) and passes once refresh() resolves outside the lock.
+TEST(TrustedProxyResolver, RefreshDoesNotBlockConcurrentIsTrusted) {
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool release_resolver = false;
+    std::atomic<bool> resolver_entered{false};
+
+    TrustedProxyResolver r("gw",
+        [&](const std::string&) -> std::vector<std::string> {
+            resolver_entered = true;
+            std::unique_lock<std::mutex> lock(gate_mutex);
+            gate_cv.wait(lock, [&] { return release_resolver; });
+            return {"10.0.0.1"};
+        });
+
+    std::thread refresher([&r] { r.refresh(); });
+
+    // Wait until refresh() is confirmed stuck inside the resolver.
+    while (!resolver_entered.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    // While refresh() is blocked inside the resolver, isTrusted() must
+    // return immediately rather than waiting for it.
+    EXPECT_FALSE(r.isTrusted("10.0.0.1"));
+
+    // Release the resolver and let refresh() finish.
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_resolver = true;
+    }
+    gate_cv.notify_one();
+    refresher.join();
+
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
 }

--- a/tests/unit/test_trusted_proxy_resolver.cpp
+++ b/tests/unit/test_trusted_proxy_resolver.cpp
@@ -61,3 +61,28 @@ TEST(TrustedProxyResolver, KeepsLastGoodOnResolutionFailure) {
     EXPECT_TRUE(r.isTrusted("10.0.0.1"));   // call 1: good set stored
     EXPECT_TRUE(r.isTrusted("10.0.0.1"));   // call 2: failure -> keep old set
 }
+
+// Regression test: a multi-host CSV list must not let one host's transient
+// resolution failure evict another host's previously-good IPs.
+TEST(TrustedProxyResolver, MultiHostPartialFailureKeepsOtherHostGoodIps) {
+    std::atomic<int> hostBCalls{0};
+    TrustedProxyResolver r("hostA,hostB", 0, // always stale
+        [&hostBCalls](const std::string& host) -> std::vector<std::string> {
+            if (host == "hostA") {
+                return {"10.0.0.1"};  // hostA always resolves successfully
+            }
+            // hostB: succeeds on first call, fails (empty) afterwards.
+            return (++hostBCalls == 1) ? std::vector<std::string>{"10.0.0.2"}
+                                        : std::vector<std::string>{};
+        });
+
+    // First call: both hosts resolve successfully -> both IPs trusted.
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    EXPECT_TRUE(r.isTrusted("10.0.0.2"));
+
+    // Second call: refresh_sec=0 re-triggers resolution; hostB now fails.
+    // hostA's IP must remain trusted, and hostB's previously-good IP must
+    // NOT be evicted just because hostB failed this round.
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    EXPECT_TRUE(r.isTrusted("10.0.0.2"));
+}

--- a/tests/unit/test_trusted_proxy_resolver.cpp
+++ b/tests/unit/test_trusted_proxy_resolver.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "server/TrustedProxyResolver.h"
+#include <algorithm>
 #include <atomic>
 
 TEST(TrustedProxyResolver, EmptyHostsDisabled) {
@@ -85,4 +86,41 @@ TEST(TrustedProxyResolver, MultiHostPartialFailureKeepsOtherHostGoodIps) {
     // NOT be evicted just because hostB failed this round.
     EXPECT_TRUE(r.isTrusted("10.0.0.1"));
     EXPECT_TRUE(r.isTrusted("10.0.0.2"));
+}
+
+// Exercises the real getaddrinfo-backed resolver (no injected ResolveFn).
+// "localhost" resolves deterministically via /etc/hosts, no network needed.
+TEST(TrustedProxyResolver, DefaultResolverResolvesLocalhost) {
+    auto ips = TrustedProxyResolver::defaultResolver("localhost");
+    ASSERT_FALSE(ips.empty());
+    bool has_loopback = std::find(ips.begin(), ips.end(), "127.0.0.1") != ips.end() ||
+                         std::find(ips.begin(), ips.end(), "::1") != ips.end();
+    EXPECT_TRUE(has_loopback);
+}
+
+TEST(TrustedProxyResolver, DefaultResolverReturnsEmptyForUnresolvableHost) {
+    auto ips = TrustedProxyResolver::defaultResolver("this-host-does-not-exist.invalid");
+    EXPECT_TRUE(ips.empty());
+}
+
+// Whitespace around hosts and empty segments between commas must be
+// trimmed/dropped so the resolver queries clean hostnames.
+TEST(TrustedProxyResolver, ParsesCsvWithWhitespaceAndEmptySegments) {
+    TrustedProxyResolver r(" hostA , , hostB ", 30,
+        [](const std::string& host) -> std::vector<std::string> {
+            if (host == "hostA") return {"10.0.0.1"};
+            if (host == "hostB") return {"10.0.0.2"};
+            return {};  // untrimmed host string (e.g. " hostA ") would land here
+        });
+    EXPECT_TRUE(r.enabled());
+    EXPECT_TRUE(r.isTrusted("10.0.0.1"));
+    EXPECT_TRUE(r.isTrusted("10.0.0.2"));
+}
+
+// A CSV string that is only whitespace/commas has no real hosts -> disabled,
+// same as an empty string.
+TEST(TrustedProxyResolver, AllWhitespaceOrEmptySegmentsCsvDisabled) {
+    TrustedProxyResolver r(" , ,  ", 30);
+    EXPECT_FALSE(r.enabled());
+    EXPECT_FALSE(r.isTrusted("127.0.0.1"));
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Looking at this code change, I need to understand what functionality was added and what problem it solves.

From the changes:

1. **New TrustedProxyResolver class** - This is the core new component that:
   - Takes a list of comma-separated hostnames (trusted proxies)
   - Resolves these hostnames to IP addresses via DNS
   - Caches the resolved IPs
   - Allows connections from these IPs to bypass the per-IP connection limit
   - Has fail-closed behavior (if a hostname never resolves, nothing is trusted)
   - Uses fail-closed but keeps last known-good IPs on transient failures

2. **ConnectionLimiter changes**:
   - Modified `tryAcquire()` to accept a `trusted` boolean parameter
   - When `trusted` is true, the per-IP limit is bypassed but the global limit still applies

3. **ServerConfig changes**:
   - Added `trusted_proxy_hosts` (comma-separated hostnames)
   - Added `trusted_proxy_refresh_sec` (DNS refresh interval, default 30s)

4. **Main server changes**:
   - Parse new CLI arguments (`--trusted-proxy-hosts`, `--trusted-proxy-refresh-sec`)
   - Parse new environment variables (`TRUSTED_PROXY_HOSTS`, `TRUSTED_PROXY_REFRESH_SEC`)
   - Create TrustedProxyResolver instance
   - Run a background thread to periodically refresh DNS resolution
   - Check if incoming connections are from trusted IPs and pass this to the connection limiter

5. **Tests**:
   - Added tests for ConnectionLimiter with trusted IPs
   - Added comprehensive tests for TrustedProxyResolver

6. **README updates**:
   - Added documentation about the Trusted Proxy Exemption feature

The purpose is clear: In production environments, there's often a single gateway (like `jota-gateway`) that proxies many users from one IP address. The per-IP connection limit was becoming a bottleneck because all users appeared to come from the same IP. 

The solution enables operators to designate a trusted gateway by hostname that can exceed the per-IP connection threshold while still respecting the global connection cap. This feature is opt-in and disabled by default.
</think>

## Summary

This pull request implements a **trusted proxy exemption** feature that allows specific gateway hosts to bypass the per-IP connection limit while still respecting the global connection cap.

### What was changed

1. **New TrustedProxyResolver component** (`TrustedProxyResolver.h/cpp`)
   - Resolves configured hostnames to IP addresses via DNS (IPv4 + IPv6)
   - Provides `isTrusted(ip)` method to check if an IP belongs to a trusted gateway
   - Implements fail-closed behavior: if a hostname never resolves, no IP is trusted
   - Keeps last-known-good IPs on transient DNS resolution failures
   - Refreshes DNS on a configurable interval (default 30 seconds)
   - Thread-safe: DNS resolution happens outside the lock to never block `isTrusted()` calls

2. **ConnectionLimiter enhancement**
   - Modified `tryAcquire(ip, trusted)` to accept a `trusted` parameter
   - When `trusted=true`, the per-IP limit is bypassed, but the global limit always applies

3. **Server configuration**
   - Added `--trusted-proxy-hosts HOSTS` CLI flag and `TRUSTED_PROXY_HOSTS` env var
   - Added `--trusted-proxy-refresh-sec N` CLI flag and `TRUSTED_PROXY_REFRESH_SEC` env var

4. **Server startup logic**
   - Creates TrustedProxyResolver instance
   - Runs a background thread to periodically refresh DNS resolution
   - Checks incoming connections against the trusted IP cache

5. **Tests**
   - Added 10 new tests for ConnectionLimiter trusted IP behavior
   - Added 12 new tests for TrustedProxyResolver (empty hosts, resolution, fail-closed, concurrency)

### Why it matters

In production, a single gateway (e.g., `jota-gateway`) often proxies many users from one IP address. The per-IP connection limit was effectively becoming a global cap for all real users. This feature allows operators to exempt a trusted gateway by hostname, enabling the gateway to handle more simultaneous connections while still protecting the service from abuse by untrusted clients.
<!-- kody-pr-summary:end -->