### PR TITLE
feat(vad): silence gating real con Silero VAD (whisper.cpp) — Hilo C de #64

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,14 @@ cmake --build build -j$(nproc)
 ./build/tests/test_streaming_whisper --gtest_filter=StreamingWhisperTest.TranscribeSilence
 ```
 
-Tests require a model file at `third_party/whisper.cpp/models/ggml-base.bin`.
+Tests require a model file at `third_party/whisper.cpp/models/ggml-base.bin`. VAD-gated tests (`test_vad_gate.cpp`, and `StreamingWhisperEngineTest.GatedLongSilencePreservesBothUtterances`) additionally require the Silero VAD model at `third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin` — they `GTEST_SKIP()` when it's absent.
 
 ## Running the Server
 
 ```bash
+# Download the Silero VAD model (required — silence gating is always on)
+./third_party/whisper.cpp/models/download-vad-model.sh silero-v5.1.2
+
 # Run Server:
 ./build/jota-transcriber --model /path/to/ggml-base.bin
 # Or with params:
@@ -45,8 +48,13 @@ Tests require a model file at `third_party/whisper.cpp/models/ggml-base.bin`.
     --whisper-beam-size 5 --whisper-threads 4 \
     --auth-token YOUR_TOKEN \
     --cert server.crt --key server.key \
-    --max-connections 8 --max-connections-per-ip 2
+    --max-connections 8 --max-connections-per-ip 2 \
+    --vad-model third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin
 ```
+
+### VAD silence gating (Silero, always on)
+
+Runs whisper.cpp's public Silero VAD API (`whisper_vad_*`) in front of Whisper decoding, trimming silences ≥ `--vad-min-silence-ms` before inference. Implemented in `src/whisper/VadGate.h`/`.cpp`, wired through `StreamingWhisperEngine::setVadConfig()`. No env-var override — configure via CLI flags only (see `--vad-*` in `--help`) or `docker-compose.yml`'s `command:`. This is distinct from the older `vad_thold` client config / `--whisper-no-speech-thold`, which only tune Whisper's internal no-speech heuristic and are not real silence detection.
 
 # Generate self-signed certs
 ./generate_certs.sh
@@ -61,7 +69,7 @@ docker-compose up --build
 docker-compose build
 ```
 
-Model files must be placed in `./models/` before starting (mounted to `/app/models/` in container). Default model: `ggml-base.bin`.
+Model files must be placed in `./models/` before starting (mounted to `/app/models/` in container). Default model: `ggml-base.bin`. Also place the Silero VAD model (`ggml-silero-v5.1.2.bin`) in `./models/` — `docker-compose.yml` passes `--vad-model /app/models/ggml-silero-v5.1.2.bin` explicitly since VAD flags have no env-var override.
 
 ## Architecture
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(third_party/whisper.cpp)
 # Librería StreamingWhisperEngine (independiente de Boost/OpenSSL)
 add_library(streaming_whisper
     src/whisper/StreamingWhisperEngine.cpp
+    src/whisper/VadGate.cpp
 )
 
 target_include_directories(streaming_whisper PUBLIC

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ cmake --build build -j$(nproc)
 # Example: small model (~500 MB, good balance of speed and accuracy)
 cd third_party/whisper.cpp/models
 ./download-ggml-model.sh small
+
+# Silero VAD model (required — silence gating is always on)
+./download-vad-model.sh silero-v5.1.2
 ```
 
 ### Run
@@ -104,7 +107,7 @@ docker-compose build --build-arg GGML_CUDA=0
 docker-compose up
 ```
 
-Model files must be placed in `./models/` before starting (mounted at `/app/models/` inside the container).
+Model files must be placed in `./models/` before starting (mounted at `/app/models/` inside the container). This must include the Silero VAD model (`ggml-silero-v5.1.2.bin`) alongside the main Whisper model — silence gating is always on and has no environment-variable override, so `docker-compose.yml` passes `--vad-model /app/models/ggml-silero-v5.1.2.bin` explicitly.
 
 ## CLI Reference
 
@@ -129,8 +132,15 @@ Model files must be placed in `./models/` before starting (mounted at `/app/mode
 | `--max-concurrent-inference N` | `4` | Max simultaneous Whisper decodes |
 | `--model-cache-ttl N` | `300` | Seconds to keep model loaded after last session (-1 = forever) |
 | `--whisper-initial-prompt TEXT` | — | Decoder initial prompt for vocabulary guidance |
+| `--vad-model PATH` | `third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin` | Silero VAD model file — silence gating is always on |
+| `--vad-threshold F` | `0.5` | VAD speech probability threshold |
+| `--vad-min-speech-ms N` | `250` | Minimum speech segment duration |
+| `--vad-min-silence-ms N` | `2000` | Silence ≥ this duration is trimmed before Whisper decoding |
+| `--vad-max-speech-s F` | unlimited | Max speech segment duration before a forced split |
+| `--vad-speech-pad-ms N` | `400` | Audio kept on each side of a detected speech segment |
+| `--vad-samples-overlap F` | `0.1` | Overlap (seconds) between adjacent speech segments |
 
-All flags are also available as environment variables (see `.env.example`).
+All flags are also available as environment variables (see `.env.example`), **except the `--vad-*` flags**, which are CLI-only — pass them via `command:` in `docker-compose.yml` if not using the defaults.
 
 ## WebSocket Protocol
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     network_mode: host
     env_file:
       - .env
+    # VAD (Silero) silence gating is always on and has no env-var override —
+    # point it at the model mounted from ./models/. Place
+    # ggml-silero-v5.1.2.bin in ./models/ alongside the main model
+    # (download with: ./third_party/whisper.cpp/models/download-vad-model.sh silero-v5.1.2).
+    command: ["--vad-model", "/app/models/ggml-silero-v5.1.2.bin"]
     volumes:
       - ./models:/app/models
       # Mount SSL certs if needed

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -177,8 +177,18 @@ void printUsage(const char* binary) {
               << " [--max-concurrent-inference N] [--model-cache-ttl N]"
               << " [--whisper-initial-prompt TEXT] [--session-timeout-sec N] [--shutdown-timeout-sec N]"
               << " [--flush-min-new-audio-ms N]"
+              << " [--vad-model PATH] [--vad-threshold F] [--vad-min-speech-ms N]"
+              << " [--vad-min-silence-ms N] [--vad-max-speech-s F] [--vad-speech-pad-ms N]"
+              << " [--vad-samples-overlap F]"
               << " [--env-file path]"
               << " [--max-upload-bytes N]" << std::endl;
+    std::cout << "  --vad-model PATH           VAD (Silero) model file (default: third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin)\n"
+              << "  --vad-threshold F          VAD speech probability threshold (default: 0.5)\n"
+              << "  --vad-min-speech-ms N      min speech segment duration (default: 250)\n"
+              << "  --vad-min-silence-ms N     silence >= this is trimmed before Whisper (default: 2000)\n"
+              << "  --vad-max-speech-s F       max speech segment before forced split (default: unlimited)\n"
+              << "  --vad-speech-pad-ms N      audio kept each side of a kept segment (default: 400)\n"
+              << "  --vad-samples-overlap F    overlap seconds between segments (default: 0.1)\n";
     std::cout << "All options can also be set via environment variables (or a .env file):" << std::endl;
     std::cout << "  MODEL_PATH, BIND_ADDRESS, PORT," << std::endl;
     std::cout << "  AUTH_TOKEN, AUTH_API_URL, AUTH_API_SECRET, AUTH_CACHE_TTL, AUTH_API_TIMEOUT," << std::endl;
@@ -261,6 +271,20 @@ ServerConfig parseArgs(int argc, char* argv[]) {
             config.whisper_logprob_thold = std::stof(argv[++i]);
         } else if (arg == "--flush-min-new-audio-ms" && i + 1 < argc) {
             config.flush_min_new_audio_ms = std::stoi(argv[++i]);
+        } else if (arg == "--vad-model" && i + 1 < argc) {
+            config.vad_model_path = argv[++i];
+        } else if (arg == "--vad-threshold" && i + 1 < argc) {
+            config.vad_threshold = std::stof(argv[++i]);
+        } else if (arg == "--vad-min-speech-ms" && i + 1 < argc) {
+            config.vad_min_speech_ms = std::stoi(argv[++i]);
+        } else if (arg == "--vad-min-silence-ms" && i + 1 < argc) {
+            config.vad_min_silence_ms = std::stoi(argv[++i]);
+        } else if (arg == "--vad-max-speech-s" && i + 1 < argc) {
+            config.vad_max_speech_s = std::stof(argv[++i]);
+        } else if (arg == "--vad-speech-pad-ms" && i + 1 < argc) {
+            config.vad_speech_pad_ms = std::stoi(argv[++i]);
+        } else if (arg == "--vad-samples-overlap" && i + 1 < argc) {
+            config.vad_samples_overlap = std::stof(argv[++i]);
         } else if (arg == "--thread-safe") {
             // accepted for backwards compatibility
         } else if (arg.rfind("--", 0) != 0 &&
@@ -356,7 +380,11 @@ void handleSession(tcp::socket socket,
                 config.whisper_initial_prompt, config.session_timeout_sec,
                 config.whisper_temperature, config.whisper_temperature_inc,
                 config.whisper_no_speech_thold, config.whisper_logprob_thold,
-                config.flush_min_new_audio_ms);
+                config.flush_min_new_audio_ms,
+                config.vad_model_path, config.vad_threshold,
+                config.vad_min_speech_ms, config.vad_min_silence_ms,
+                config.vad_max_speech_s, config.vad_speech_pad_ms,
+                config.vad_samples_overlap);
             session->run(req);
         } else {
             boost::beast::http::read(socket, buffer, parser);
@@ -379,7 +407,11 @@ void handleSession(tcp::socket socket,
                 config.whisper_initial_prompt, config.session_timeout_sec,
                 config.whisper_temperature, config.whisper_temperature_inc,
                 config.whisper_no_speech_thold, config.whisper_logprob_thold,
-                config.flush_min_new_audio_ms);
+                config.flush_min_new_audio_ms,
+                config.vad_model_path, config.vad_threshold,
+                config.vad_min_speech_ms, config.vad_min_silence_ms,
+                config.vad_max_speech_s, config.vad_speech_pad_ms,
+                config.vad_samples_overlap);
             session->run(req);
         }
     } catch (std::exception& e) {

--- a/src/server/ServerConfig.h
+++ b/src/server/ServerConfig.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <cfloat>
 
 struct ServerConfig {
     std::string model_path = "third_party/whisper.cpp/models/ggml-small.bin";
@@ -30,6 +31,15 @@ struct ServerConfig {
     float whisper_no_speech_thold = 0.3f;   // probability threshold to reject non-speech segments
     float whisper_logprob_thold = -0.7f;    // log-prob threshold to reject low-confidence segments (-1.0=disabled)
     int flush_min_new_audio_ms = 500;       // ms of new audio required before flushLoop re-runs inference (was hardcoded 250ms)
+
+    // VAD silence gating (Silero, via whisper.cpp public API)
+    std::string vad_model_path = "third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin";
+    float vad_threshold       = 0.5f;
+    int   vad_min_speech_ms   = 250;
+    int   vad_min_silence_ms  = 2000;
+    float vad_max_speech_s    = FLT_MAX;
+    int   vad_speech_pad_ms   = 400;
+    float vad_samples_overlap = 0.1f;
 
     int shutdown_timeout_sec = 10;      // max seconds to wait for sessions to close on SIGINT/SIGTERM
     size_t max_upload_bytes = 25 * 1024 * 1024; // 25 MB — matches OpenAI limit

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <nlohmann/json.hpp>
 #include <iostream>
+#include <cfloat>
 #include "whisper/StreamingWhisperEngine.h"
 #include "whisper/ModelCache.h"
 #include "server/SessionTracker.h"
@@ -49,7 +50,14 @@ public:
         float whisper_temperature_inc = 0.2f,
         float whisper_no_speech_thold = 0.3f,
         float whisper_logprob_thold = -1.0f,
-        int flush_min_new_audio_ms = 500
+        int flush_min_new_audio_ms = 500,
+        const std::string& vad_model_path = "",
+        float vad_threshold = 0.5f,
+        int vad_min_speech_ms = 250,
+        int vad_min_silence_ms = 2000,
+        float vad_max_speech_s = FLT_MAX,
+        int vad_speech_pad_ms = 400,
+        float vad_samples_overlap = 0.1f
     )
         : ws_(std::move(ws)),
           model_path_(model_path),
@@ -68,6 +76,13 @@ public:
           whisper_no_speech_thold_(whisper_no_speech_thold),
           whisper_logprob_thold_(whisper_logprob_thold),
           flush_min_new_audio_ms_(flush_min_new_audio_ms),
+          vad_model_path_(vad_model_path),
+          vad_threshold_(vad_threshold),
+          vad_min_speech_ms_(vad_min_speech_ms),
+          vad_min_silence_ms_(vad_min_silence_ms),
+          vad_max_speech_s_(vad_max_speech_s),
+          vad_speech_pad_ms_(vad_speech_pad_ms),
+          vad_samples_overlap_(vad_samples_overlap),
           model_acquired_(false),
           bytes_received_in_window_(0),
           rate_limit_start_(std::chrono::steady_clock::now()),
@@ -360,6 +375,12 @@ private:
                 engine_->setTemperatureInc(whisper_temperature_inc_);
                 engine_->setNoSpeechThreshold(whisper_no_speech_thold_);
                 engine_->setLogprobThreshold(whisper_logprob_thold_);
+                if (!vad_model_path_.empty()) {
+                    engine_->setVadConfig(vad_model_path_, vad_threshold_,
+                                          vad_min_speech_ms_, vad_min_silence_ms_,
+                                          vad_max_speech_s_, vad_speech_pad_ms_,
+                                          vad_samples_overlap_);
+                }
                 if (!whisper_initial_prompt_.empty()) {
                     engine_->setInitialPrompt(whisper_initial_prompt_);
                 }
@@ -489,6 +510,13 @@ private:
     float whisper_no_speech_thold_;
     float whisper_logprob_thold_;
     int flush_min_new_audio_ms_;
+    std::string vad_model_path_;
+    float vad_threshold_;
+    int   vad_min_speech_ms_;
+    int   vad_min_silence_ms_;
+    float vad_max_speech_s_;
+    int   vad_speech_pad_ms_;
+    float vad_samples_overlap_;
     bool model_acquired_;
     
     // Rate limiting & Timeout

--- a/src/whisper/StreamingWhisperEngine.cpp
+++ b/src/whisper/StreamingWhisperEngine.cpp
@@ -7,6 +7,7 @@
 #include "InferenceLimiter.h"
 #include "log/Log.h"
 #include "utils/AudioPreprocessor.h"
+#include "whisper/VadGate.h"
 
 StreamingWhisperEngine::StreamingWhisperEngine(whisper_context* shared_ctx)
     : ctx_(shared_ctx),
@@ -89,6 +90,18 @@ StreamingWhisperEngine::TranscribeResult StreamingWhisperEngine::transcribeSlidi
     }
     // buffer_mutex_ is now RELEASED — processAudioChunk() can append concurrently.
 
+    // --- Step 1.5: VAD silence gating (passthrough when not configured) ---
+    VadGate::GatedResult gated;
+    const std::vector<float>* decode_ptr = &snapshot;
+    if (vad_gate_) {
+        gated = vad_gate_->gate(snapshot);
+        if (!gated.had_speech) {
+            return {};  // nothing but silence this pass — skip decode entirely
+        }
+        decode_ptr = &gated.samples;
+    }
+    const std::vector<float>& decode_buf = *decode_ptr;
+
     // --- Step 2: Run inference on snapshot (no lock held) ---
     // Use beam search when beam_size > 1, greedy otherwise
     whisper_full_params params = (beam_size_ > 1)
@@ -124,7 +137,7 @@ StreamingWhisperEngine::TranscribeResult StreamingWhisperEngine::transcribeSlidi
     // For a 5s buffer this saves ~83% of encoder attention work over zero-padded silence.
     {
         int ctx = static_cast<int>(
-            std::ceil(static_cast<float>(snapshot.size()) / 16000.0f * 50.0f));
+            std::ceil(static_cast<float>(decode_buf.size()) / 16000.0f * 50.0f));
         params.audio_ctx = std::max(ctx, 64); // floor at 64 tokens (~1.3s)
     }
 
@@ -138,8 +151,8 @@ StreamingWhisperEngine::TranscribeResult StreamingWhisperEngine::transcribeSlidi
 
     int result = whisper_full_with_state(
         ctx_, state_, params,
-        snapshot.data(),   // use snapshot, not audio_buffer_
-        static_cast<int>(snapshot.size())
+        decode_buf.data(),
+        static_cast<int>(decode_buf.size())
     );
 
     if (result != 0) {
@@ -173,7 +186,7 @@ StreamingWhisperEngine::TranscribeResult StreamingWhisperEngine::transcribeSlidi
         } else {
             // Find the last segment that ends before the final 2 seconds of audio.
             // Whisper timestamps are in 10ms units (100 = 1 sec).
-            int64_t overlap_bounds_t = (static_cast<int64_t>(snapshot.size()) - 32000) / 160;
+            int64_t overlap_bounds_t = (static_cast<int64_t>(decode_buf.size()) - 32000) / 160;
 
             for (int i = n_segments - 1; i >= 0; --i) {
                 int64_t t1 = whisper_full_get_segment_t1_from_state(state_, i);
@@ -209,7 +222,9 @@ StreamingWhisperEngine::TranscribeResult StreamingWhisperEngine::transcribeSlidi
             {
                 std::lock_guard<std::mutex> lock(buffer_mutex_);
                 if (commit_t1 > 0) {
-                    size_t samples_to_erase = commit_t1 * 160;
+                    size_t samples_to_erase = vad_gate_
+                        ? static_cast<size_t>(vad_gate_->toOriginalSamples(commit_t1))
+                        : static_cast<size_t>(commit_t1) * 160;
                     Log::debug("Committing " + std::to_string(samples_to_erase) + " samples: '" + res.committed_text + "'");
                     if (samples_to_erase < audio_buffer_.size()) {
                         audio_buffer_.erase(audio_buffer_.begin(),
@@ -300,6 +315,25 @@ void StreamingWhisperEngine::setNoSpeechThreshold(float no_speech_thold) {
 
 void StreamingWhisperEngine::setLogprobThreshold(float logprob_thold) {
     logprob_thold_ = logprob_thold;
+}
+
+void StreamingWhisperEngine::setVadConfig(const std::string& model_path,
+                                          float threshold,
+                                          int min_speech_ms,
+                                          int min_silence_ms,
+                                          float max_speech_s,
+                                          int speech_pad_ms,
+                                          float samples_overlap) {
+    whisper_vad_params p = whisper_vad_default_params();
+    p.threshold               = threshold;
+    p.min_speech_duration_ms  = min_speech_ms;
+    p.min_silence_duration_ms = min_silence_ms;
+    p.max_speech_duration_s   = max_speech_s;
+    p.speech_pad_ms           = speech_pad_ms;
+    p.samples_overlap         = samples_overlap;
+    vad_gate_ = std::make_unique<VadGate>(model_path, p, n_threads_);
+    Log::info("VAD gating enabled (min_silence_ms=" + std::to_string(min_silence_ms) +
+              ", speech_pad_ms=" + std::to_string(speech_pad_ms) + ")");
 }
 
 bool StreamingWhisperEngine::isReady() const {

--- a/src/whisper/StreamingWhisperEngine.h
+++ b/src/whisper/StreamingWhisperEngine.h
@@ -7,6 +7,7 @@
 // Forward declarations
 struct whisper_context;
 struct whisper_state;
+class VadGate;
 
 /**
  * @brief Motor de transcripción en streaming usando whisper.cpp
@@ -104,7 +105,19 @@ public:
     void setTemperatureInc(float temperature_inc);
     void setNoSpeechThreshold(float no_speech_thold);
     void setLogprobThreshold(float logprob_thold);
-    
+
+    /**
+     * @brief Enable Silero-VAD silence gating (server-configured, always-on in
+     *        production). No-op path preserved when never called.
+     */
+    void setVadConfig(const std::string& model_path,
+                      float threshold,
+                      int min_speech_ms,
+                      int min_silence_ms,
+                      float max_speech_s,
+                      int speech_pad_ms,
+                      float samples_overlap);
+
     /**
      * @brief Verificar si el engine está listo
      */
@@ -123,6 +136,7 @@ public:
 private:
     whisper_context* ctx_;       // Shared, NOT owned
     whisper_state*   state_;     // Owned, per-session
+    std::unique_ptr<VadGate> vad_gate_;  // null => gating disabled (passthrough)
     std::vector<float> audio_buffer_;
     mutable std::mutex buffer_mutex_;
     

--- a/src/whisper/VadGate.cpp
+++ b/src/whisper/VadGate.cpp
@@ -1,6 +1,7 @@
 #include "whisper/VadGate.h"
 
 #include <algorithm>
+#include <cmath>   // std::lround
 #include <stdexcept>
 #include <utility>
 
@@ -53,7 +54,81 @@ void VadGate::ensureLoaded() {
     vad_ctx_.reset(raw);
 }
 
-VadGate::GatedResult VadGate::gate(const std::vector<float>& /*original*/) {
-    // Implemented in Task 2.
-    return {};
+VadGate::GatedResult VadGate::gate(const std::vector<float>& original) {
+    mapping_.clear();
+    original_total_samples_ = static_cast<int64_t>(original.size());
+
+    GatedResult out;
+    if (original.empty()) return out;  // had_speech == false
+
+    ensureLoaded();  // may throw
+
+    // Own the segments handle via unique_ptr so it is freed on every path.
+    auto seg_deleter = [](whisper_vad_segments* s) {
+        if (s) whisper_vad_free_segments(s);
+    };
+    std::unique_ptr<whisper_vad_segments, decltype(seg_deleter)> segments(
+        whisper_vad_segments_from_samples(
+            vad_ctx_.get(), params_,
+            original.data(), static_cast<int>(original.size())),
+        seg_deleter);
+
+    if (!segments) {
+        throw std::runtime_error("[VadGate] whisper_vad_segments_from_samples failed");
+    }
+
+    const int n = whisper_vad_segments_n_segments(segments.get());
+    if (n == 0) return out;  // all silence -> had_speech == false
+
+    constexpr int kSampleRate = 16000;
+    const int total = static_cast<int>(original.size());
+    const int pad = (params_.speech_pad_ms * kSampleRate) / 1000;   // samples each side
+    const int gap = (100 * kSampleRate) / 1000;                     // 100 ms synthetic
+
+    auto cs_to_samples = [&](float cs) -> int {
+        // segment boundaries are centiseconds (float); clamp into [0, total].
+        long v = std::lround((static_cast<double>(cs) / 100.0) * kSampleRate);
+        if (v < 0) v = 0;
+        if (v > total) v = total;
+        return static_cast<int>(v);
+    };
+
+    int64_t gated_cursor = 0;
+    int prev_seg_end = 0;  // guards against padding-induced overlap (monotonicity)
+
+    for (int i = 0; i < n; ++i) {
+        const float t0 = whisper_vad_segments_get_segment_t0(segments.get(), i);
+        const float t1 = whisper_vad_segments_get_segment_t1(segments.get(), i);
+        int orig_start = cs_to_samples(t0);
+        int orig_end   = cs_to_samples(t1);
+
+        // Apply symmetric padding, clamped to the buffer and to the previous
+        // segment's end so original time stays strictly monotonic.
+        int seg_start = std::max({0, orig_start - pad, prev_seg_end});
+        int seg_end   = std::min(total, orig_end + pad);
+        if (seg_end <= seg_start) continue;
+        prev_seg_end = seg_end;
+
+        const int64_t gated_start = gated_cursor;
+        // Bounds-checked iterator range copy — no raw pointer arithmetic.
+        out.samples.insert(out.samples.end(),
+                           original.begin() + seg_start,
+                           original.begin() + seg_end);
+        gated_cursor += (seg_end - seg_start);
+        const int64_t gated_end = gated_cursor;
+
+        mapping_.push_back({gated_start, gated_end,
+                            static_cast<int64_t>(seg_start),
+                            static_cast<int64_t>(seg_end)});
+
+        // Synthetic silence between (not after) segments so Whisper still sees
+        // a boundary but the long original silence is gone.
+        if (i < n - 1) {
+            out.samples.insert(out.samples.end(), static_cast<size_t>(gap), 0.0f);
+            gated_cursor += gap;
+        }
+    }
+
+    out.had_speech = !out.samples.empty();
+    return out;
 }

--- a/src/whisper/VadGate.cpp
+++ b/src/whisper/VadGate.cpp
@@ -1,0 +1,59 @@
+#include "whisper/VadGate.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+VadGate::VadGate(std::string model_path, whisper_vad_params params, int n_threads)
+    : model_path_(std::move(model_path)), params_(params), n_threads_(n_threads) {}
+
+VadGate::~VadGate() = default;  // unique_ptr custom deleter frees the context
+
+int64_t VadGate::mapGatedToOriginalSamples(
+        const std::vector<SegmentMapping>& mapping,
+        int64_t gated_samples,
+        int64_t original_total_samples) {
+    if (gated_samples <= 0 || mapping.empty()) return 0;
+
+    for (size_t i = 0; i < mapping.size(); ++i) {
+        const auto& seg = mapping[i];
+        if (gated_samples < seg.gated_start) {
+            // Falls before this segment. If i==0 it is before all speech -> 0.
+            // Otherwise it is inside the synthetic gap after the previous
+            // segment -> map to the previous segment's original end (safe:
+            // that boundary only ever discards already-silent original audio).
+            return (i == 0) ? 0 : mapping[i - 1].original_end;
+        }
+        if (gated_samples < seg.gated_end) {
+            // Inside this speech segment: 1:1 offset within the segment.
+            return seg.original_start + (gated_samples - seg.gated_start);
+        }
+    }
+    // Past the last segment's gated_end -> clamp to last original end.
+    int64_t last_end = mapping.back().original_end;
+    return std::min(last_end, original_total_samples);
+}
+
+int64_t VadGate::toOriginalSamples(int64_t gated_t_centiseconds) const {
+    // whisper timestamps are in centiseconds; 1 cs = 160 samples @16kHz.
+    const int64_t gated_samples = gated_t_centiseconds * 160;
+    return mapGatedToOriginalSamples(mapping_, gated_samples, original_total_samples_);
+}
+
+void VadGate::ensureLoaded() {
+    if (vad_ctx_) return;
+    whisper_vad_context_params cparams = whisper_vad_default_context_params();
+    cparams.n_threads = n_threads_;
+    cparams.use_gpu   = false;  // Silero is tiny; keep it off the main-model GPU
+    whisper_vad_context* raw =
+        whisper_vad_init_from_file_with_params(model_path_.c_str(), cparams);
+    if (!raw) {
+        throw std::runtime_error("[VadGate] Failed to load VAD model: " + model_path_);
+    }
+    vad_ctx_.reset(raw);
+}
+
+VadGate::GatedResult VadGate::gate(const std::vector<float>& /*original*/) {
+    // Implemented in Task 2.
+    return {};
+}

--- a/src/whisper/VadGate.h
+++ b/src/whisper/VadGate.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <whisper.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Silero-VAD silence gate in front of Whisper decoding.
+ *
+ * Runs whisper.cpp's public Silero VAD over a PCM snapshot and returns a
+ * trimmed buffer with long silences (>= min_silence_duration_ms) removed,
+ * plus a mapping that lets callers translate a timestamp in the trimmed
+ * ("gated") timeline back to a sample offset in the original buffer.
+ *
+ * Ownership: the whisper_vad_context is owned via a unique_ptr with a custom
+ * deleter (RAII). Non-copyable AND non-movable — hold it via unique_ptr.
+ *
+ * Not thread-safe: one instance per session, called only from that session's
+ * inference path.
+ */
+class VadGate {
+public:
+    /// One anchor: a contiguous speech region copied into the gated buffer.
+    /// All fields are sample offsets (16 kHz).
+    struct SegmentMapping {
+        int64_t gated_start;
+        int64_t gated_end;
+        int64_t original_start;
+        int64_t original_end;
+    };
+
+    struct GatedResult {
+        std::vector<float> samples;   ///< buffer to feed to whisper (trimmed)
+        bool had_speech = false;      ///< false => skip decoding this pass
+    };
+
+    VadGate(std::string model_path, whisper_vad_params params, int n_threads);
+    ~VadGate();
+
+    VadGate(const VadGate&) = delete;
+    VadGate& operator=(const VadGate&) = delete;
+    VadGate(VadGate&&) = delete;
+    VadGate& operator=(VadGate&&) = delete;
+
+    /// Run VAD over `original` and build the trimmed buffer + internal mapping.
+    /// @throws std::runtime_error if the VAD model fails to load/run.
+    GatedResult gate(const std::vector<float>& original);
+
+    /// Translate a whisper timestamp (centiseconds, gated timeline) to an
+    /// offset in the ORIGINAL buffer (samples). Uses the mapping built by the
+    /// most recent gate() call. Returns 0 if no mapping is available.
+    int64_t toOriginalSamples(int64_t gated_t_centiseconds) const;
+
+    /// Pure, model-free translation used by toOriginalSamples(). Exposed for
+    /// testing. `mapping` must be sorted ascending by gated_start.
+    static int64_t mapGatedToOriginalSamples(
+        const std::vector<SegmentMapping>& mapping,
+        int64_t gated_samples,
+        int64_t original_total_samples);
+
+private:
+    void ensureLoaded();  ///< lazy-load the VAD model on first use
+
+    struct VadCtxDeleter {
+        void operator()(whisper_vad_context* c) const {
+            if (c) whisper_vad_free(c);
+        }
+    };
+
+    std::string model_path_;
+    whisper_vad_params params_;
+    int n_threads_;
+    std::unique_ptr<whisper_vad_context, VadCtxDeleter> vad_ctx_;  // null until first gate()
+    std::vector<SegmentMapping> mapping_;                          // rebuilt each gate()
+    int64_t original_total_samples_ = 0;                           // from last gate()
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(unit_tests
     unit/test_session_tracker.cpp
     unit/test_model_cache.cpp
     unit/test_streaming_whisper_engine.cpp
+    unit/test_vad_gate.cpp
     unit/test_streaming_session.cpp
     unit/test_audio_decoder.cpp
     unit/test_multipart_parser.cpp

--- a/tests/unit/test_streaming_whisper_engine.cpp
+++ b/tests/unit/test_streaming_whisper_engine.cpp
@@ -111,6 +111,18 @@ TEST_F(StreamingWhisperEngineTest, TranscribeEmptyBufferReturnsEmpty) {
     EXPECT_TRUE(res.partial_text.empty());
 }
 
+TEST_F(StreamingWhisperEngineTest, PassthroughWhenVadNotConfigured) {
+    // With no setVadConfig() call, gating is disabled and the engine behaves
+    // exactly as before: a 3 s silence snapshot still decodes (no skip).
+    StreamingWhisperEngine engine(ctx_);
+    engine.processAudioChunk(std::vector<float>(16000 * 3, 0.0f));
+    ASSERT_NO_THROW({
+        auto res = engine.transcribeSlidingWindow(true);
+        (void)res;  // no crash / no early-return path taken
+    });
+    EXPECT_EQ(engine.getBufferSize(), 0u);  // force_commit clears buffer
+}
+
 // ─── Configuración ───────────────────────────────────────────────────────────
 
 TEST_F(StreamingWhisperEngineTest, SetLanguageDoesNotCrash) {

--- a/tests/unit/test_streaming_whisper_engine.cpp
+++ b/tests/unit/test_streaming_whisper_engine.cpp
@@ -5,6 +5,9 @@
 #include <thread>
 #include <atomic>
 #include <cmath>
+#include <fstream>
+#include <cstdint>
+#include <cfloat>
 
 #ifndef PROJECT_ROOT
 #define PROJECT_ROOT "."
@@ -93,6 +96,9 @@ TEST_F(StreamingWhisperEngineTest, SlidingWindowNoForceDoesNotCommitShortBuffer)
     EXPECT_TRUE(res.committed_text.empty());
 }
 
+// No setVadConfig() call: exercises the passthrough (no-gate) path on silence.
+// Real VAD gating of silence is covered separately by
+// GatedLongSilencePreservesBothUtterances below.
 TEST_F(StreamingWhisperEngineTest, ForceCommitClearsBuffer) {
     StreamingWhisperEngine engine(ctx_);
     engine.setLanguage("es");
@@ -121,6 +127,64 @@ TEST_F(StreamingWhisperEngineTest, PassthroughWhenVadNotConfigured) {
         (void)res;  // no crash / no early-return path taken
     });
     EXPECT_EQ(engine.getBufferSize(), 0u);  // force_commit clears buffer
+}
+
+// Minimal PCM16 mono WAV loader (jfk.wav is 16 kHz mono 16-bit). Finds the
+// "data" chunk and converts int16 -> float32 in [-1, 1].
+static std::vector<float> loadWavMono16k(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return {};
+    std::vector<char> bytes((std::istreambuf_iterator<char>(f)),
+                             std::istreambuf_iterator<char>());
+    // Locate "data" chunk id.
+    size_t i = 12;
+    while (i + 8 <= bytes.size()) {
+        uint32_t sz = static_cast<uint8_t>(bytes[i+4]) |
+                      (static_cast<uint8_t>(bytes[i+5]) << 8) |
+                      (static_cast<uint8_t>(bytes[i+6]) << 16) |
+                      (static_cast<uint8_t>(bytes[i+7]) << 24);
+        if (bytes[i]=='d' && bytes[i+1]=='a' && bytes[i+2]=='t' && bytes[i+3]=='a') {
+            std::vector<float> out;
+            size_t start = i + 8;
+            size_t end = std::min(bytes.size(), start + sz);
+            for (size_t p = start; p + 1 < end; p += 2) {
+                int16_t s = static_cast<uint8_t>(bytes[p]) |
+                            (static_cast<int16_t>(bytes[p+1]) << 8);
+                out.push_back(s / 32768.0f);
+            }
+            return out;
+        }
+        i += 8 + sz + (sz & 1);
+    }
+    return {};
+}
+
+TEST_F(StreamingWhisperEngineTest, GatedLongSilencePreservesBothUtterances) {
+    const std::string vadModel =
+        std::string(PROJECT_ROOT) + "/third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin";
+    const std::string wav =
+        std::string(PROJECT_ROOT) + "/third_party/whisper.cpp/samples/jfk.wav";
+    if (!std::filesystem::exists(vadModel) || !std::filesystem::exists(wav)) {
+        GTEST_SKIP() << "VAD model or jfk.wav not found";
+    }
+    std::vector<float> speech = loadWavMono16k(wav);
+    ASSERT_FALSE(speech.empty());
+
+    StreamingWhisperEngine engine(ctx_);
+    engine.setLanguage("en");
+    engine.setVadConfig(vadModel, 0.5f, 250, 2000, FLT_MAX, 400, 0.1f);
+
+    // utterance | 4 s silence | utterance
+    engine.processAudioChunk(speech);
+    engine.processAudioChunk(std::vector<float>(16000 * 4, 0.0f));
+    engine.processAudioChunk(speech);
+
+    auto res = engine.transcribeSlidingWindow(true);
+    std::string text = res.committed_text;
+    // JFK sample contains "ask not what your country"; expect it present and
+    // no crash / no buffer-translation drift (force_commit clears buffer).
+    EXPECT_NE(text.find("country"), std::string::npos);
+    EXPECT_EQ(engine.getBufferSize(), 0u);
 }
 
 // ─── Configuración ───────────────────────────────────────────────────────────

--- a/tests/unit/test_vad_gate.cpp
+++ b/tests/unit/test_vad_gate.cpp
@@ -2,6 +2,43 @@
 
 #include "whisper/VadGate.h"
 
+#include <filesystem>
+#include <whisper.h>
+
+#ifndef PROJECT_ROOT
+#define PROJECT_ROOT "."
+#endif
+
+static const std::string VAD_MODEL_PATH =
+    std::string(PROJECT_ROOT) + "/third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin";
+
+static VadGate makeGate() {
+    whisper_vad_params p = whisper_vad_default_params();
+    p.threshold               = 0.5f;
+    p.min_speech_duration_ms  = 250;
+    p.min_silence_duration_ms = 2000;
+    p.speech_pad_ms           = 400;
+    return VadGate(VAD_MODEL_PATH, p, 4);
+}
+
+TEST(VadGateBehavior, EmptyInputHasNoSpeech) {
+    VadGate gate = makeGate();
+    auto result = gate.gate({});
+    EXPECT_FALSE(result.had_speech);
+    EXPECT_TRUE(result.samples.empty());
+}
+
+TEST(VadGateBehavior, PureSilenceHasNoSpeech) {
+    if (!std::filesystem::exists(VAD_MODEL_PATH)) {
+        GTEST_SKIP() << "VAD model not found: " << VAD_MODEL_PATH;
+    }
+    VadGate gate = makeGate();
+    std::vector<float> silence(16000 * 4, 0.0f);  // 4 s of zeros
+    auto result = gate.gate(silence);
+    EXPECT_FALSE(result.had_speech);
+    EXPECT_TRUE(result.samples.empty());
+}
+
 // Mapping fixture: two speech segments in the ORIGINAL timeline:
 //   seg A: original [0, 16000)      -> gated [0, 16000)
 //   (100 ms = 1600 samples synthetic silence gap in gated timeline)

--- a/tests/unit/test_vad_gate.cpp
+++ b/tests/unit/test_vad_gate.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include "whisper/VadGate.h"
+
+// Mapping fixture: two speech segments in the ORIGINAL timeline:
+//   seg A: original [0, 16000)      -> gated [0, 16000)
+//   (100 ms = 1600 samples synthetic silence gap in gated timeline)
+//   seg B: original [80000, 96000)  -> gated [17600, 33600)
+// i.e. 4 s of original silence between A and B was collapsed to 100 ms.
+static std::vector<VadGate::SegmentMapping> twoSegmentMapping() {
+    return {
+        {0,     16000, 0,     16000},
+        {17600, 33600, 80000, 96000},
+    };
+}
+
+TEST(VadGateMapping, InsideFirstSegmentMapsOneToOne) {
+    auto m = twoSegmentMapping();
+    // gated sample 8000 is halfway through seg A -> original 8000
+    EXPECT_EQ(VadGate::mapGatedToOriginalSamples(m, 8000, 96000), 8000);
+}
+
+TEST(VadGateMapping, InsideSecondSegmentMapsWithOffset) {
+    auto m = twoSegmentMapping();
+    // gated 25600 is 8000 into seg B (gated_start 17600) -> original 80000+8000
+    EXPECT_EQ(VadGate::mapGatedToOriginalSamples(m, 25600, 96000), 88000);
+}
+
+TEST(VadGateMapping, InSyntheticGapMapsToSegmentEnd) {
+    auto m = twoSegmentMapping();
+    // gated 16800 is inside the 1600-sample gap after seg A -> original end of A
+    EXPECT_EQ(VadGate::mapGatedToOriginalSamples(m, 16800, 96000), 16000);
+}
+
+TEST(VadGateMapping, PastLastSegmentClampsToLastOriginalEnd) {
+    auto m = twoSegmentMapping();
+    EXPECT_EQ(VadGate::mapGatedToOriginalSamples(m, 999999, 96000), 96000);
+}
+
+TEST(VadGateMapping, NonPositiveMapsToZero) {
+    auto m = twoSegmentMapping();
+    EXPECT_EQ(VadGate::mapGatedToOriginalSamples(m, 0, 96000), 0);
+    EXPECT_EQ(VadGate::mapGatedToOriginalSamples(m, -5, 96000), 0);
+}
+
+TEST(VadGateMapping, EmptyMappingReturnsZero) {
+    std::vector<VadGate::SegmentMapping> empty;
+    EXPECT_EQ(VadGate::mapGatedToOriginalSamples(empty, 5000, 96000), 0);
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
The user wants me to analyze the code changes and generate a precise description for a pull request. Let me analyze the changes:

1. **New VAD (Voice Activity Detection) feature**: The main change is adding Silero VAD-based silence gating to the streaming whisper transcriber.

2. **New files added**:
   - `src/whisper/VadGate.h` and `src/whisper/VadGate.cpp` - New class that implements VAD-based silence gating using whisper.cpp's public Silero VAD API
   - `tests/unit/test_vad_gate.cpp` - Unit tests for the VadGate class

3. **Modified files**:
   - `CLAUDE.md`, `README.md`, `docker-compose.yml` - Documentation updates for the new VAD feature
   - `CMakeLists.txt` - Added VadGate.cpp to the build
   - `src/server.cpp` - Added VAD CLI flags
   - `src/server/ServerConfig.h` - Added VAD configuration parameters
   - `src/server/StreamingSession.h` - Added VAD parameters to session
   - `src/whisper/StreamingWhisperEngine.cpp` and `.h` - Integrated VAD gating into the transcription pipeline
   - `tests/CMakeLists.txt` - Added test_vad_gate.cpp
   - `tests/unit/test_streaming_whisper_engine.cpp` - Added tests for VAD integration

Key functional changes:
- Silero VAD silence gating is always on in production (not optional)
- The VAD trims silences ≥ `--vad-min-silence-ms` (default 2000ms) before Whisper inference
- No environment variable override - CLI-only configuration
- Added new CLI flags: `--vad-model`, `--vad-threshold`, `--vad-min-speech-ms`, `--vad-min-silence-ms`, `--vad-max-speech-s`, `--vad-speech-pad-ms`, `--vad-samples-overlap`


- The VadGate class leverages whisper.cpp's `whisper_vad_*` APIs to detect speech segments, strip out extended silences, and maintain a mapping between gated and original audio timestamps so transcription results can be accurately positioned in the original stream
- Existing behavior remains intact when VAD is disabled, allowing the system to function with or without voice activity detection
</think>

## Summary

This pull request implements **real Silero VAD-based silence gating** for the streaming Whisper transcriber, replacing the previous "fake" VAD approach that only tuned Whisper's internal no-speech heuristic.

### Key Changes

1. **New VadGate Component** (`src/whisper/VadGate.h/cpp`): A new class that wraps whisper.cpp's public Silero VAD API (`whisper_vad_*`), which:
   - Runs VAD over each audio snapshot before Whisper inference
   - Trims silences ≥ configured threshold (default 2000ms) from the audio buffer
   - Builds a mapping between the trimmed ("gated") timeline and original samples, enabling accurate timestamp translation
   - Skips Whisper decoding entirely when only silence is detected

2. **CLI Configuration**: New VAD-specific flags (no env-var override):
   - `--vad-model`, `--vad-threshold`, `--vad-min-speech-ms`, `--vad-min-silence-ms`, `--vad-max-speech-s`, `--vad-speech-pad-ms`, `--vad-samples-overlap`

3. **Integration**: `StreamingWhisperEngine::setVadConfig()` wires the VAD gate into the transcription pipeline. When not called, the passthrough path preserves original behavior.

4. **Tests**: Added unit tests for the mapping logic (`test_vad_gate.cpp`) and integration tests in `test_streaming_whisper_engine.cpp` that verify VAD-gated silence is properly handled and both utterances around a long silence are preserved.

5. **Documentation**: Updated README, CLAUDE.md, and docker-compose.yml to reflect the always-on VAD requirement and new configuration options.
<!-- kody-pr-summary:end -->