### PR TITLE
fix: silenciar warnings deprecated de libavcodec en path legacy de AudioDecoder

### DIFF
--- a/src/audio/AudioDecoder.cpp
+++ b/src/audio/AudioDecoder.cpp
@@ -140,6 +140,8 @@ std::vector<float> AudioDecoder::decode(const std::vector<uint8_t>& data) {
     av_opt_set_chlayout(swr, "in_chlayout",  &codec_ctx->ch_layout, 0);
     av_opt_set_chlayout(swr, "out_chlayout", &out_layout, 0);
 #else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     int64_t in_layout = codec_ctx->channel_layout
         ? codec_ctx->channel_layout
         : av_get_default_channel_layout(codec_ctx->channels);
@@ -147,6 +149,7 @@ std::vector<float> AudioDecoder::decode(const std::vector<uint8_t>& data) {
     av_opt_set_int(swr, "out_channel_layout", AV_CH_LAYOUT_MONO,  0);
     av_opt_set_int(swr, "in_channel_count",   codec_ctx->channels,0);
     av_opt_set_int(swr, "out_channel_count",  1,                  0);
+#pragma GCC diagnostic pop
 #endif
     av_opt_set_int(swr,        "in_sample_rate",  codec_ctx->sample_rate, 0);
     av_opt_set_int(swr,        "out_sample_rate", 16000,                  0);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
The user wants me to analyze a code change (patch) and generate a description for a pull request based on the changes.

Looking at the patch:
- File: `src/audio/AudioDecoder.cpp`
- The change adds `#pragma GCC diagnostic push`, `#pragma GCC diagnostic ignored "-Wdeprecated-declarations"` before some legacy code, and `#pragma GCC diagnostic pop` after it.

The code being wrapped is:
```cpp
int64_t in_layout = codec_ctx->channel_layout
    ? codec_ctx->channel_layout
    : av_get_default_channel_layout(codec_ctx->channels);
av_opt_set_int(swr, "in_channel_layout",  in_layout,          0);
av_opt_set_int(swr, "out_channel_layout", AV_CH_LAYOUT_MONO,  0);
av_opt_set_int(swr, "in_channel_count",   codec_ctx->channels,0);
av_opt_set_int(swr, "out_channel_count",  1,                  0);
```

This is in the `#else` block (meaning it's for a legacy path, likely for older FFmpeg versions that don't support the newer channel layout API).

The changes:
1. Added `#pragma GCC diagnostic push` to save the current diagnostic state
2. Added `#pragma GCC diagnostic ignored "-Wdeprecated-declarations"` to suppress deprecated warnings
3. The legacy code that uses deprecated APIs
4. Added `#pragma GCC diagnostic pop` to restore the diagnostic state

This is specifically for the legacy path in AudioDecoder that uses older FFmpeg APIs which are now deprecated.

The PR title says: "fix: silenciar warnings deprecated de libavcodec en path legacy de AudioDecoder"

Translation: "fix: silence deprecated warnings from libavcodec in AudioDecoder legacy path"


I'll focus on the key technical details of the patch. The modification targets a specific legacy code path in the audio decoder, strategically using compiler diagnostic pragmas to suppress warnings from deprecated FFmpeg library functions. This ensures clean compilation while maintaining compatibility with older FFmpeg versions.

The implementation involves carefully wrapping deprecated API calls to prevent warning pollution, demonstrating a pragmatic approach to handling API evolution in cross-version compatibility scenarios.
</think>

## Summary

This pull request fixes the deprecated warnings generated by the legacy path in `AudioDecoder.cpp` when using older FFmpeg APIs.

The changes wrap the legacy code block (which uses deprecated functions like `channel_layout`, `channel_count`, and related functions from older libavcodec versions) with GCC diagnostic pragmas to suppress the `-Wdeprecated-declarations` warnings. This prevents these warnings from appearing during compilation while maintaining backward compatibility with older FFmpeg versions that don't support the newer channel layout API.
<!-- kody-pr-summary:end -->