### PR TITLE
fix: Docker build stub list drift + deploy config/docs audit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 build/
 .git/
 models/
-mosquitto/
 *.bin

--- a/.env.example
+++ b/.env.example
@@ -11,11 +11,18 @@ MODEL_PATH=/app/models/ggml-medium.bin
 BIND_ADDRESS=0.0.0.0
 PORT=8003
 
-# Auth API (leave AUTH_API_URL empty to disable authentication)
-AUTH_API_URL=http://internal-api
-AUTH_API_SECRET=your_secret_key_here
-AUTH_CACHE_TTL=300
-AUTH_API_TIMEOUT=5
+# Auth: leaving BOTH AUTH_TOKEN and AUTH_API_URL empty disables authentication
+# entirely (any token accepted) — only safe when network placement already
+# restricts who can reach this port (e.g. network_mode: host, no public bind).
+#
+# Static token (recommended when you want auth — takes effect only if AUTH_API_URL is empty):
+#AUTH_TOKEN=your_static_token_here
+#
+# External auth API (legacy jota-db path — being phased out, prefer AUTH_TOKEN):
+#AUTH_API_URL=http://internal-api
+#AUTH_API_SECRET=your_secret_key_here
+#AUTH_CACHE_TTL=300
+#AUTH_API_TIMEOUT=5
 
 # Whisper quality tuning
 WHISPER_BEAM_SIZE=5
@@ -23,6 +30,19 @@ WHISPER_THREADS=4
 MAX_CONCURRENT_INFERENCE=4
 MODEL_CACHE_TTL=300
 #WHISPER_INITIAL_PROMPT="Transcripción en español de España"
+
+# Whisper decoder tuning (advanced — values below are the ServerConfig.h defaults,
+# spelled out so you don't have to go read the source to know what's active)
+WHISPER_TEMPERATURE=0.0
+WHISPER_TEMPERATURE_INC=0.0
+WHISPER_NO_SPEECH_THOLD=0.3
+WHISPER_LOGPROB_THOLD=-0.7
+
+# ms of new audio required before flushLoop re-runs inference
+FLUSH_MIN_NEW_AUDIO_MS=500
+
+# Max HTTP upload size in bytes (POST /v1/audio/transcriptions) — 25 MB, matches OpenAI's limit
+MAX_UPLOAD_BYTES=26214400
 
 # TLS (leave empty to use plain WS)
 TLS_CERT=server.crt
@@ -32,11 +52,13 @@ TLS_KEY=server.key
 MAX_CONNECTIONS=8
 MAX_CONNECTIONS_PER_IP=2
 
-# Session and handshake timeouts
+# Session, handshake and shutdown timeouts
 # session_timeout_sec: idle session disconnect (seconds). Default: 30
 # handshake_timeout_sec: TLS/HTTP-upgrade handshake deadline (seconds). Default: 10
+# shutdown_timeout_sec: max wait for sessions to close on SIGINT/SIGTERM. Default: 10
 SESSION_TIMEOUT_SEC=30
 HANDSHAKE_TIMEOUT_SEC=10
+SHUTDOWN_TIMEOUT_SEC=10
 
 # Trusted proxy exemption (leave TRUSTED_PROXY_HOSTS empty to disable — default)
 # CSV hostnames exempt from MAX_CONNECTIONS_PER_IP (e.g. a shared gateway).
@@ -44,3 +66,5 @@ HANDSHAKE_TIMEOUT_SEC=10
 #TRUSTED_PROXY_HOSTS=jota-gateway
 TRUSTED_PROXY_REFRESH_SEC=30
 
+# NOTE: --vad-* flags (Silero VAD silence gating) have NO env-var override.
+# Configure them via `command:` in docker-compose.yml. See CLAUDE.md.

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,12 @@ COPY CMakeLists.txt .
 # que la configuración pase sin necesitar src/ todavía (se sobreescriben luego).
 RUN mkdir -p src/whisper src/server src/server/handlers src/auth src/audio && \
     touch src/whisper/StreamingWhisperEngine.cpp \
+          src/whisper/VadGate.cpp \
           src/server.cpp \
           src/server/StreamingSession.cpp \
           src/server/AuthManager.cpp \
           src/server/ConnectionLimiter.cpp \
+          src/server/TrustedProxyResolver.cpp \
           src/server/ConnectionGuard.cpp \
           src/auth/ApiAuthClient.cpp \
           src/auth/AuthCache.cpp \

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd third_party/whisper.cpp/models
 ./generate_certs.sh
 ```
 
-> **Note on auth:** `AUTH_API_URL` was originally designed to point to `jota-db`. The recommended path forward is per-service `AUTH_TOKEN` (static), with `AUTH_API_URL` kept only for setups that still centralize auth via `jota-db`. The deprecation of `jota-db` as default auth backend is tracked in [`Jota-project/jota-gateway` issues](https://github.com/Jota-project/jota-gateway/issues).
+> **Note on auth:** `AUTH_API_URL` was originally designed to point to `jota-db`. The recommended path forward is per-service `AUTH_TOKEN` (static), with `AUTH_API_URL` kept only for setups that still centralize auth via `jota-db`. The deprecation of `jota-db` as default auth backend is tracked in [`Jota-project/jota-gateway` issues](https://github.com/Jota-project/jota-gateway/issues). Leaving **both** `AUTH_TOKEN` and `AUTH_API_URL` empty disables authentication entirely — every token is accepted. Only rely on this when network placement already restricts who can reach the port (e.g. `network_mode: host` with no public bind, or a firewalled internal network).
 
 ### Run tests
 
@@ -105,12 +105,9 @@ Tests that require a model file skip automatically if `third_party/whisper.cpp/m
 ## Docker
 
 ```bash
-# Build and start with GPU
+# Build and start (requires an NVIDIA GPU — this Dockerfile always builds
+# with CUDA baked in, there is no CPU-only build target)
 docker-compose up --build
-
-# CPU only
-docker-compose build --build-arg GGML_CUDA=0
-docker-compose up
 ```
 
 Model files must be placed in `./models/` before starting (mounted at `/app/models/` inside the container). This must include the Silero VAD model (`ggml-silero-v5.1.2.bin`) alongside the main Whisper model — silence gating is always on and has no environment-variable override, so `docker-compose.yml` passes `--vad-model /app/models/ggml-silero-v5.1.2.bin` explicitly.
@@ -140,6 +137,12 @@ Model files must be placed in `./models/` before starting (mounted at `/app/mode
 | `--max-concurrent-inference N` | `4` | Max simultaneous Whisper decodes |
 | `--model-cache-ttl N` | `300` | Seconds to keep model loaded after last session (-1 = forever) |
 | `--whisper-initial-prompt TEXT` | — | Decoder initial prompt for vocabulary guidance |
+| `--whisper-temperature F` | `0.0` | Initial sampling temperature (`0.0` = greedy, fastest for streaming) |
+| `--whisper-temperature-inc F` | `0.0` | Temperature increment on repetition fallback (`0.0` disables fallback) |
+| `--whisper-no-speech-thold F` | `0.3` | Probability threshold to reject non-speech segments |
+| `--whisper-logprob-thold F` | `-0.7` | Log-prob threshold to reject low-confidence segments (`-1.0` disables) |
+| `--flush-min-new-audio-ms N` | `500` | ms of new audio required before `flushLoop` re-runs inference |
+| `--max-upload-bytes N` | `26214400` (25 MB) | Max body size for `POST /v1/audio/transcriptions` |
 | `--vad-model PATH` | `third_party/whisper.cpp/models/ggml-silero-v5.1.2.bin` | Silero VAD model file — silence gating is always on |
 | `--vad-threshold F` | `0.5` | VAD speech probability threshold |
 | `--vad-min-speech-ms N` | `250` | Minimum speech segment duration |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   server:
     build: .
@@ -12,7 +10,18 @@ services:
     # point it at the model mounted from ./models/. Place
     # ggml-silero-v5.1.2.bin in ./models/ alongside the main model
     # (download with: ./third_party/whisper.cpp/models/download-vad-model.sh silero-v5.1.2).
-    command: ["--vad-model", "/app/models/ggml-silero-v5.1.2.bin"]
+    # Values below match the design decision in
+    # docs/superpowers/specs/2026-07-15-transcriber-vad-gating-design.md —
+    # kept explicit here (rather than relying on binary defaults) so a future
+    # default change in code can't silently alter production behavior.
+    command: [
+      "--vad-model", "/app/models/ggml-silero-v5.1.2.bin",
+      "--vad-threshold", "0.5",
+      "--vad-min-speech-ms", "250",
+      "--vad-min-silence-ms", "2000",
+      "--vad-speech-pad-ms", "400",
+      "--vad-samples-overlap", "0.1"
+    ]
     volumes:
       - ./models:/app/models
       # Mount SSL certs if needed


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what this pull request implements:

1. **`.dockerignore`**: Removed `mosquitto/` from the list of ignored files/directories.

2. **`Dockerfile`**: Added two more source files to the stub list:
   - `src/whisper/VadGate.cpp`
   - `src/server/TrustedProxyResolver.cpp`
   
   This is a fix for "stub list drift" - where the list of stub files in the Dockerfile gets out of sync with the actual source files that need to exist for the CMake configuration to succeed.

3. **`README.md`**: 
   - Added documentation about the authentication behavior when both `AUTH_TOKEN` and `AUTH_API_URL` are empty (disables auth entirely)
   - Updated the Docker section to remove the CPU-only build option (now always builds with CUDA)
   - Added documentation for several new command-line parameters:
     - `--whisper-temperature`
     - `--whisper-temperature-inc`
     - `--whisper-no-speech-thold`
     - `--whisper-logprob-thold`
     - `--flush-min-new-audio-ms`
     - `--max-upload-bytes`

4. **`docker-compose.yml`**:
   - Removed the `version: '3.8'` line (deprecated in modern Compose)
   - Made the command more explicit by adding all VAD-related parameters instead of just `--vad-model`
   - Added documentation in comments explaining why these values are explicitly set

So the main purposes are:
1. Fix the Dockerfile stub list drift (add missing stub files)
2. Deploy config/docs audit - update documentation and docker-compose to explicitly set parameters that were previously relying on defaults
3. Clean up deprecated configuration (remove CPU-only build option, remove docker-compose version)

This appears to be about keeping the build configuration in sync with the actual code and making deployment configuration more explicit/auditable.
</think>

This pull request addresses two main issues: **Dockerfile stub list drift** and **deployment configuration/documentation audit**.

## Changes Summary

**1. Dockerfile Stub List Fix**
Added two missing stub files to the CMake configuration step:
- `src/whisper/VadGate.cpp`
- `src/server/TrustedProxyResolver.cpp`

These source files exist in the codebase but were missing from the Dockerfile's stub list, which would cause the Docker build to fail.

**2. .dockerignore Update**
Removed `mosquitto/` from ignored entries, allowing that directory to be included in the build context if needed.

**3. docker-compose.yml Improvements**
- Removed the deprecated `version: '3.8'` line
- Made VAD parameters explicit in the command rather than relying on binary defaults:
  - `--vad-threshold`, `--vad-min-speech-ms`, `--vad-min-silence-ms`, `--vad-speech-pad-ms`, `--vad-samples-overlap`
- Added comments explaining these values align with the design specification document

**4. README.md Updates**
- Added documentation for new command-line parameters: `--whisper-temperature`, `--whisper-temperature-inc`, `--whisper-no-speech-thold`, `--whisper-logprob-thold`, `--flush-min-new-audio-ms`, `--max-upload-bytes`
- Clarified that leaving both `AUTH_TOKEN` and `AUTH_API_URL` empty disables authentication entirely
- Removed the CPU-only build option from the Docker section (CUDA is now always baked in)
<!-- kody-pr-summary:end -->