### PR TITLE
fix: restore binary name in docker-compose command override

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     # kept explicit here (rather than relying on binary defaults) so a future
     # default change in code can't silently alter production behavior.
     command: [
+      "./jota-transcriber",
       "--vad-model", "/app/models/ggml-silero-v5.1.2.bin",
       "--vad-threshold", "0.5",
       "--vad-min-speech-ms", "250",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
The user wants me to analyze the code change and generate a description for a pull request.

Looking at the patch:
- File modified: `docker-compose.yml`
- Change: Added `"./jota-transcriber"` to the command array in the docker-compose configuration

The change is adding the binary name `./jota-transcriber` back to the command override in docker-compose.yml. The comment in the code explains why this was done explicitly - to avoid a future default change in code silently altering production behavior.

So the purpose of this change is to explicitly specify the binary name in the docker-compose command, ensuring the correct binary is always executed regardless of any potential default changes in the code.

This is a fix to restore the binary name that was apparently missing from the docker-compose command override.
</think>

**Summary:**

Added the explicit binary name `./jota-transcriber` to the docker-compose command override in `docker-compose.yml`.

**What was changed:**

The command array in the docker-compose configuration was missing the binary executable name. This change restores `./jota-transcriber` as the first element of the command array.

**Why this matters:**

As noted in the existing comment, keeping the binary name explicit ensures that future changes to default values in the code won't silently alter production behavior. This provides stability and predictability in how the service is started in the Docker Compose environment.
<!-- kody-pr-summary:end -->