### PR TITLE
feat: WebSocket backpressure — flow_control pause/resume + dropped_chunks warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ ws.send(float_samples.tobytes())
 |---|---|
 | `ready` | Session configured successfully |
 | `transcription` | Partial (`is_final: false`) or final (`is_final: true`) result |
-| `warning` | Non-fatal issue (e.g. `code: "buffer_full"` when the 20s buffer is saturated) |
+| `warning` | Non-fatal issue. `code: "buffer_full"` when the 20s buffer is saturated — sent every 10 dropped chunks while it stays saturated (field `dropped_chunks`, resets to 0 each time the buffer drains and a new saturation episode starts) |
+| `flow_control` | `action: "pause"` when the buffer hits the 20s high-water mark and the server starts dropping incoming audio; `action: "resume"` once it drains back below the 10s low-water mark. Informational — the server keeps dropping audio at the high-water mark regardless of whether the client honors this signal |
 | `error` | Fatal session error — connection closes after `AUTH_FAILED`, `AUTH_REQUIRED` |
 
 ### End of stream

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ High-performance real-time audio transcription microservice built with C++17 and
 - Authentication: static token or external API with in-memory cache
 - Per-IP and global connection limits, with an opt-in DNS-based exemption for a trusted gateway proxy
 - Non-blocking inference — GPU saturation skips a cycle instead of blocking
-- Audio buffer high-water mark (20s) with client-side warning
+- Audio buffer high-water mark (20s) with `flow_control` pause/resume and `dropped_chunks` warnings
 - Hallucination guard against Whisper decoder loops
 - Prometheus metrics at `/metrics`, health check at `/health`, readiness at `/ready`
 - Docker with NVIDIA GPU support

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -223,7 +223,6 @@ private:
             Log::warn("Audio buffer full, entrando en pausa de flujo", session_id_);
             sendMessage({{"type", "flow_control"}, {"action", "pause"}});
         }
-        constexpr size_t WARNING_INTERVAL_CHUNKS = 10;
         if (overflow && current_dropped % WARNING_INTERVAL_CHUNKS == 0) {
             sendMessage({
                 {"type", "warning"},
@@ -395,6 +394,8 @@ private:
                 configured_ = true;
                 last_transcribed_size_ = 0;
                 capacity_degraded_ = false;
+                buffer_overflowed_ = false;
+                dropped_chunks_ = 0;
                 full_transcription_    = "";
                 raw_transcription_     = "";
                 last_audio_time_ = std::chrono::steady_clock::now();
@@ -502,6 +503,7 @@ private:
     std::unique_ptr<StreamingWhisperEngine> engine_;
     std::string session_id_;
     bool configured_;
+    static constexpr size_t WARNING_INTERVAL_CHUNKS = 10; // how often a dropped_chunks warning is re-sent during a saturation episode
     bool buffer_overflowed_; // true while a saturation episode (HWM..LWM hysteresis) is active
     size_t dropped_chunks_;  // chunks dropped in the CURRENT episode; resets to 0 when it ends
     bool capacity_degraded_; // true while this session's own inference cycles are being skipped (GPU saturated)
@@ -644,7 +646,6 @@ private:
             // episode is over: report any drops not yet covered by a periodic warning,
             // tell the client it can resume, then reset for the next episode.
             constexpr size_t LOW_WATER_MARK = 16000 * 10;
-            constexpr size_t WARNING_INTERVAL_CHUNKS = 10;
             if (buffer_overflowed_ && engine_->getBufferSize() < LOW_WATER_MARK) {
                 // Snapshot while still locked — dropped_chunks_ is state_mutex_-protected
                 // state written by processAudioChunk() on the WS receive thread, so it

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -65,6 +65,7 @@ public:
           auth_manager_(auth_manager),
           configured_(false),
           buffer_overflowed_(false),
+          dropped_chunks_(0),
           capacity_degraded_(false),
           last_transcribed_size_(0),
           language_("es"),
@@ -210,18 +211,26 @@ private:
 
         last_audio_time_ = std::chrono::steady_clock::now();
         bool overflow = engine_->processAudioChunk(audio);
-        bool should_warn = overflow && !buffer_overflowed_;
-        buffer_overflowed_ = overflow;
+        bool entering_episode = overflow && !buffer_overflowed_;
+        size_t current_dropped = 0;
+        if (overflow) {
+            buffer_overflowed_ = true;
+            current_dropped = ++dropped_chunks_;
+        }
         lock.unlock();
 
-        if (should_warn) {
-            Log::warn("Audio buffer full, dropping incoming audio", session_id_);
-            json warning = {
+        if (entering_episode) {
+            Log::warn("Audio buffer full, entrando en pausa de flujo", session_id_);
+            sendMessage({{"type", "flow_control"}, {"action", "pause"}});
+        }
+        constexpr size_t WARNING_INTERVAL_CHUNKS = 10;
+        if (overflow && current_dropped % WARNING_INTERVAL_CHUNKS == 0) {
+            sendMessage({
                 {"type", "warning"},
                 {"code", "buffer_full"},
+                {"dropped_chunks", current_dropped},
                 {"message", "Audio buffer full, dropping incoming audio"}
-            };
-            sendMessage(warning);
+            });
         }
         // Inference is handled entirely by flushLoop to avoid blocking the receive loop.
     }
@@ -493,7 +502,8 @@ private:
     std::unique_ptr<StreamingWhisperEngine> engine_;
     std::string session_id_;
     bool configured_;
-    bool buffer_overflowed_; // true while engine buffer is above 20s HWM
+    bool buffer_overflowed_; // true while a saturation episode (HWM..LWM hysteresis) is active
+    size_t dropped_chunks_;  // chunks dropped in the CURRENT episode; resets to 0 when it ends
     bool capacity_degraded_; // true while this session's own inference cycles are being skipped (GPU saturated)
     size_t last_transcribed_size_;
     std::string language_;

--- a/src/server/StreamingSession.h
+++ b/src/server/StreamingSession.h
@@ -640,11 +640,33 @@ private:
             auto res = engine_->transcribeSlidingWindow(false);
             // inf_guard releases the slot automatically on scope exit (including exceptions)
 
-            // If inference drained the buffer below HWM, reset the overflow flag so the
-            // next saturation episode triggers a new warning regardless of client audio timing.
-            constexpr size_t HIGH_WATER_MARK = 16000 * 20;
-            if (buffer_overflowed_ && engine_->getBufferSize() < HIGH_WATER_MARK) {
+            // If inference drained the buffer below the low-water mark, the saturation
+            // episode is over: report any drops not yet covered by a periodic warning,
+            // tell the client it can resume, then reset for the next episode.
+            constexpr size_t LOW_WATER_MARK = 16000 * 10;
+            constexpr size_t WARNING_INTERVAL_CHUNKS = 10;
+            if (buffer_overflowed_ && engine_->getBufferSize() < LOW_WATER_MARK) {
+                // Snapshot while still locked — dropped_chunks_ is state_mutex_-protected
+                // state written by processAudioChunk() on the WS receive thread, so it
+                // must not be read unlocked from this (flushLoop) thread below.
+                size_t dropped_snapshot = dropped_chunks_;
+                if (dropped_snapshot % WARNING_INTERVAL_CHUNKS != 0) {
+                    lock.unlock();
+                    sendMessage({
+                        {"type", "warning"},
+                        {"code", "buffer_full"},
+                        {"dropped_chunks", dropped_snapshot},
+                        {"message", "Audio buffer full, dropping incoming audio"}
+                    });
+                    lock.lock();
+                }
+                Log::info("flushLoop: saliendo de pausa de flujo (dropped=" +
+                          std::to_string(dropped_snapshot) + ")", session_id_);
+                lock.unlock();
+                sendMessage({{"type", "flow_control"}, {"action", "resume"}});
+                lock.lock();
                 buffer_overflowed_ = false;
+                dropped_chunks_ = 0;
             }
 
             // Hallucination guard: filter loops before updating state or sending to client.

--- a/tests/unit/test_streaming_session.cpp
+++ b/tests/unit/test_streaming_session.cpp
@@ -15,6 +15,8 @@
 #include <atomic>
 #include <cstring>
 #include <future>
+#include <fstream>
+#include <filesystem>
 
 static std::vector<unsigned char> toBytes(const std::vector<float>& samples) {
     std::vector<unsigned char> bytes(samples.size() * sizeof(float));
@@ -104,7 +106,13 @@ protected:
         }
     }
 
-    uint16_t startServer(bool require_auth = false, int session_timeout_sec = 30) {
+    // model_path_override: empty string (the default) uses the fast structural-only
+    // stub model (for-tests-ggml-tiny.bin, zero real tensors — fine for every test
+    // that only checks protocol/session behavior). Tests that need Whisper to
+    // actually produce non-empty segments (e.g. real buffer draining via committed
+    // text) must pass a real model path explicitly.
+    uint16_t startServer(bool require_auth = false, int session_timeout_sec = 30,
+                          const std::string& model_path_override = "") {
         tcp::endpoint endpoint(net::ip::make_address("127.0.0.1"), 0);
         acceptor_ = std::make_unique<tcp::acceptor>(ioc_, endpoint);
         uint16_t port = acceptor_->local_endpoint().port();
@@ -116,24 +124,27 @@ protected:
         }
         auto auth_manager = std::make_shared<AuthManager>(auth_cfg);
 
-        doAccept(auth_manager, session_timeout_sec);
+        doAccept(auth_manager, session_timeout_sec, model_path_override);
 
         server_thread_ = std::thread([this]() { ioc_.run(); });
         return port;
     }
 
-    void doAccept(std::shared_ptr<AuthManager> auth_manager, int session_timeout_sec = 30) {
+    void doAccept(std::shared_ptr<AuthManager> auth_manager, int session_timeout_sec = 30,
+                  const std::string& model_path_override = "") {
         acceptor_->async_accept(
-            [this, auth_manager, session_timeout_sec](boost::system::error_code ec, tcp::socket socket) {
+            [this, auth_manager, session_timeout_sec, model_path_override](boost::system::error_code ec, tcp::socket socket) {
                 if (!ec) {
                     session_threads_.emplace_back(
-                        [this, s = std::move(socket), auth_manager, session_timeout_sec]() mutable {
+                        [this, s = std::move(socket), auth_manager, session_timeout_sec, model_path_override]() mutable {
                             try {
                                 boost::beast::flat_buffer buffer;
                                 boost::beast::http::request<boost::beast::http::string_body> req;
                                 boost::beast::http::read(s, buffer, req);
 
-                                std::string model_path = std::string(PROJECT_ROOT) + "/third_party/whisper.cpp/models/for-tests-ggml-tiny.bin";
+                                std::string model_path = !model_path_override.empty()
+                                    ? model_path_override
+                                    : std::string(PROJECT_ROOT) + "/third_party/whisper.cpp/models/for-tests-ggml-tiny.bin";
 
                                 websocket::stream<tcp::socket> ws(std::move(s));
                                 auto session = std::make_shared<StreamingSession<websocket::stream<tcp::socket>>>(
@@ -145,7 +156,7 @@ protected:
                                 session->run(req);
                             } catch (...) {}
                         });
-                    doAccept(auth_manager, session_timeout_sec);
+                    doAccept(auth_manager, session_timeout_sec, model_path_override);
                 }
             });
     }
@@ -392,6 +403,122 @@ TEST_F(StreamingSessionTest, FlowControlPauseAndPeriodicWarningOnSustainedOverfl
     auto warn2 = client.recvJson();
     EXPECT_EQ(warn2["type"], "warning");
     EXPECT_EQ(warn2["dropped_chunks"], 20);
+}
+
+// Minimal PCM16 mono WAV loader (jfk.wav is 16 kHz mono 16-bit). Finds the
+// "data" chunk and converts int16 -> float32 in [-1, 1].
+static std::vector<float> loadWavMono16k(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return {};
+    std::vector<char> bytes((std::istreambuf_iterator<char>(f)),
+                             std::istreambuf_iterator<char>());
+    size_t i = 12;
+    while (i + 8 <= bytes.size()) {
+        uint32_t sz = static_cast<uint8_t>(bytes[i+4]) |
+                      (static_cast<uint8_t>(bytes[i+5]) << 8) |
+                      (static_cast<uint8_t>(bytes[i+6]) << 16) |
+                      (static_cast<uint8_t>(bytes[i+7]) << 24);
+        if (bytes[i]=='d' && bytes[i+1]=='a' && bytes[i+2]=='t' && bytes[i+3]=='a') {
+            std::vector<float> out;
+            size_t start = i + 8;
+            size_t end = std::min(bytes.size(), start + sz);
+            for (size_t p = start; p + 1 < end; p += 2) {
+                int16_t s = static_cast<uint8_t>(bytes[p]) |
+                            (static_cast<int16_t>(bytes[p+1]) << 8);
+                out.push_back(s / 32768.0f);
+            }
+            return out;
+        }
+        i += 8 + sz + (sz & 1);
+    }
+    return {};
+}
+
+TEST_F(StreamingSessionTest, FlowControlResumeAfterRealDrainAndCounterResetsNextEpisode) {
+    const std::string wav = std::string(PROJECT_ROOT) + "/third_party/whisper.cpp/samples/jfk.wav";
+    if (!std::filesystem::exists(wav)) {
+        GTEST_SKIP() << "jfk.wav not found";
+    }
+    // This test needs Whisper to actually commit real segments so the buffer
+    // drains — the fixture's default model (for-tests-ggml-tiny.bin) has zero
+    // real tensors and always returns 0 segments regardless of input (see
+    // CLAUDE.md: tests requiring real transcription need a real model file).
+    const std::string real_model = std::string(PROJECT_ROOT) + "/third_party/whisper.cpp/models/ggml-base.bin";
+    if (!std::filesystem::exists(real_model)) {
+        GTEST_SKIP() << "Real model not found: " << real_model;
+    }
+    std::vector<float> speech = loadWavMono16k(wav);
+    ASSERT_FALSE(speech.empty());
+
+    auto port = startServer(false, 30, real_model);
+    auto client = connect(port);
+
+    client.sendJson({{"type", "config"}, {"language", "en"}});
+    EXPECT_EQ(client.recvJson()["type"], "ready");
+
+    // Two copies of jfk.wav (~22s) push the buffer past the 20s HWM without any
+    // individual chunk being dropped: each precheck compares against the buffer
+    // size BEFORE that chunk (0s, then ~11s — both under 20s).
+    client.sendBinary(toBytes(speech));
+    client.sendBinary(toBytes(speech));
+
+    // 12 filler chunks sent while the buffer already sits above HWM — all dropped.
+    std::vector<float> filler(3200, 0.0f); // 0.2s @16kHz
+    for (int i = 0; i < 12; ++i) {
+        client.sendBinary(toBytes(filler));
+    }
+
+    // Drain messages until flow_control:resume shows up. flushLoop's sliding window
+    // commits nearly the whole buffer (it keeps ~2s as overlap context), which lands
+    // comfortably below the 10s LWM on its first real pass over this ~22s buffer.
+    bool got_pause = false, got_resume = false;
+    int periodic_warning_dropped = -1;
+    int tail_warning_dropped = -1;
+    for (int i = 0; i < 200 && !got_resume; ++i) {
+        auto msg = client.recvJson();
+        if (msg["type"] == "flow_control" && msg["action"] == "pause") {
+            got_pause = true;
+        } else if (msg["type"] == "flow_control" && msg["action"] == "resume") {
+            got_resume = true;
+        } else if (msg["type"] == "warning" && msg["code"] == "buffer_full") {
+            int dropped = msg["dropped_chunks"].get<int>();
+            if (dropped % 10 == 0) periodic_warning_dropped = dropped;
+            else tail_warning_dropped = dropped;
+        }
+    }
+
+    ASSERT_TRUE(got_pause) << "Expected flow_control pause when buffer exceeded HWM";
+    ASSERT_TRUE(got_resume) << "Expected flow_control resume after buffer drained below LWM";
+    EXPECT_EQ(periodic_warning_dropped, 10);
+    EXPECT_EQ(tail_warning_dropped, 12);
+
+    // Second episode: push the buffer back over HWM with a few sub-1MB silence
+    // frames (each individually accepted since the precheck compares against the
+    // current, now-small, post-resume buffer — same reasoning as the initial HWM
+    // fill in Task 1's test, and same 1MB MAX_FRAME_BYTES constraint: a single
+    // 20s/1.28MB frame would be rejected outright by handleBinaryMessage()'s
+    // oversized-frame guard, so it must be split), then drop exactly 10 filler
+    // chunks. The periodic warning must report dropped_chunks == 10, not 22 —
+    // proving the counter reset.
+    constexpr size_t HWM = 16000 * 20;
+    constexpr size_t REFILL_CHUNK_SAMPLES = 16000 * 5; // 5s, 320000 bytes per frame — under the 1MB frame limit
+    for (size_t sent = 0; sent < HWM; sent += REFILL_CHUNK_SAMPLES) {
+        client.sendBinary(toBytes(std::vector<float>(REFILL_CHUNK_SAMPLES, 0.0f)));
+    }
+    for (int i = 0; i < 10; ++i) {
+        client.sendBinary(toBytes(filler));
+    }
+
+    json second_warning;
+    for (int i = 0; i < 50; ++i) {
+        auto msg = client.recvJson();
+        if (msg["type"] == "warning" && msg["code"] == "buffer_full") {
+            second_warning = msg;
+            break;
+        }
+    }
+    ASSERT_FALSE(second_warning.is_null()) << "Expected a warning in the second episode";
+    EXPECT_EQ(second_warning["dropped_chunks"], 10);
 }
 
 TEST_F(StreamingSessionTest, DoubleConfig) {

--- a/tests/unit/test_streaming_session.cpp
+++ b/tests/unit/test_streaming_session.cpp
@@ -16,6 +16,12 @@
 #include <cstring>
 #include <future>
 
+static std::vector<unsigned char> toBytes(const std::vector<float>& samples) {
+    std::vector<unsigned char> bytes(samples.size() * sizeof(float));
+    std::memcpy(bytes.data(), samples.data(), bytes.size());
+    return bytes;
+}
+
 namespace beast = boost::beast;
 namespace http = beast::http;
 namespace websocket = beast::websocket;
@@ -343,6 +349,49 @@ TEST_F(StreamingSessionTest, EmitsStatusBusyThenOkAroundGpuSaturation) {
     auto status2 = client.recvJson();
     EXPECT_EQ(status2["type"], "status");
     EXPECT_EQ(status2["state"], "ok");
+}
+
+TEST_F(StreamingSessionTest, FlowControlPauseAndPeriodicWarningOnSustainedOverflow) {
+    auto port = startServer(false);
+    auto client = connect(port);
+
+    client.sendJson({{"type", "config"}, {"language", "es"}});
+    EXPECT_EQ(client.recvJson()["type"], "ready");
+
+    // Fill the buffer to exactly the 20s HWM using multiple sub-1MB frames (real
+    // clients never send 20s in one frame — README recommends 100-500ms chunks —
+    // and a single 1.28MB frame would collide with the 1MB MAX_FRAME_BYTES guard
+    // in handleBinaryMessage()). Each 5s/320000-byte chunk is well under that
+    // limit. The HWM check compares against the buffer size BEFORE each chunk
+    // (0s, 5s, 10s, 15s — all under 20s), so none of these fill chunks are
+    // dropped and the buffer lands exactly at HWM.
+    constexpr size_t HWM = 16000 * 20;
+    constexpr size_t FILL_CHUNK_SAMPLES = 16000 * 5; // 5s, 320000 bytes per frame — under the 1MB frame limit
+    for (size_t sent = 0; sent < HWM; sent += FILL_CHUNK_SAMPLES) {
+        client.sendBinary(toBytes(std::vector<float>(FILL_CHUNK_SAMPLES, 0.0f)));
+    }
+
+    // 25 filler chunks (0.2s each) sent while the buffer already sits at the HWM —
+    // every one of them gets dropped. Pure silence never gets committed by
+    // transcribeSlidingWindow() (whisper finds no segments), so the buffer stays
+    // flat at exactly HWM for the whole test: no race with flushLoop draining it.
+    std::vector<float> filler(3200, 0.0f); // 0.2s @16kHz
+    for (int i = 0; i < 25; ++i) {
+        client.sendBinary(toBytes(filler));
+    }
+
+    auto pause = client.recvJson();
+    EXPECT_EQ(pause["type"], "flow_control");
+    EXPECT_EQ(pause["action"], "pause");
+
+    auto warn1 = client.recvJson();
+    EXPECT_EQ(warn1["type"], "warning");
+    EXPECT_EQ(warn1["code"], "buffer_full");
+    EXPECT_EQ(warn1["dropped_chunks"], 10);
+
+    auto warn2 = client.recvJson();
+    EXPECT_EQ(warn2["type"], "warning");
+    EXPECT_EQ(warn2["dropped_chunks"], 20);
 }
 
 TEST_F(StreamingSessionTest, DoubleConfig) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what was implemented, fixed, or changed.

Looking at the changes:

1. **README.md**: Updated documentation to describe new WebSocket message types:
   - `warning` now includes a `dropped_chunks` field that counts dropped audio chunks and resets when buffer drains
   - Added new `flow_control` message type with `pause` and `resume` actions for managing backpressure

2. **src/server/StreamingSession.h**: Core implementation changes:
   - Added `dropped_chunks_` counter to track chunks dropped during buffer saturation
   - Modified `handleBinaryMessage` to:
     - Send `flow_control: pause` when buffer first hits the 20s high-water mark
     - Send periodic warnings every 10 dropped chunks with the `dropped_chunks` count
   - Modified `flushLoop` to:
     - Use low-water mark (10s) instead of high-water mark (20s) for ending saturation episodes
     - Send `flow_control: resume` when buffer drains below LWM
     - Send final warning for any remaining drops not covered by periodic warnings
     - Reset `dropped_chunks_` to 0 when saturation episode ends

3. **tests/unit/test_streaming_session.cpp**: Added comprehensive tests:
   - `FlowControlPauseAndPeriodicWarningOnSustainedOverflow`: Tests pause signal and periodic warnings
   - `FlowControlResumeAfterRealDrainAndCounterResetsNextEpisode`: Tests resume signal after buffer drains and counter reset for new episodes

The functional purpose is implementing WebSocket backpressure control:
- When the audio buffer fills up (hits 20s high-water mark), the server sends a `flow_control: pause` message
- While the buffer remains saturated, warnings are sent every 10 dropped chunks
- When the buffer drains below 10s (low-water mark), a `flow_control: resume` message is sent


- The dropped chunks counter resets after each saturation episode so it can track the next wave of backpressure
</think>

## Summary

This pull request implements WebSocket backpressure control for the streaming transcription server. The changes add flow control signaling to help clients manage audio send rates more effectively when the server's buffer becomes saturated.

### Key Changes

1. **New `flow_control` WebSocket message type**: The server now sends `flow_control` messages with `action: "pause"` when the audio buffer hits the 20-second high-water mark, and `action: "resume"` when it drains back below the 10-second low-water mark.

2. **Enhanced `warning` messages**: Warning messages for `buffer_full` now include a `dropped_chunks` field that tracks how many audio chunks have been dropped during a saturation episode. Warnings are sent every 10 dropped chunks while the buffer remains saturated, plus a final warning for any remaining drops when the episode ends.

3. **Counter reset between episodes**: The dropped chunks counter resets to 0 when the buffer drains below the low-water mark, allowing each saturation episode to be tracked independently.

### Functional Impact

- Clients receive explicit signals to pause/resume sending audio, enabling better flow control
- Periodic warnings during saturation provide visibility into how much data is being dropped
- The hysteresis between high-water (20s) and low-water (10s) marks prevents rapid flapping between pause/resume states
<!-- kody-pr-summary:end -->