### PR TITLE
fix: HandshakeWatchdog kills long-running HTTP requests, not just idle handshakes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if(BUILD_SERVER)
 
     add_executable(jota-transcriber
         src/server.cpp
+        src/server/SessionHandler.cpp
         src/server/StreamingSession.cpp
         src/server/AuthManager.cpp
         src/server/ConnectionLimiter.cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN mkdir -p src/whisper src/server src/server/handlers src/auth src/audio && \
     touch src/whisper/StreamingWhisperEngine.cpp \
           src/whisper/VadGate.cpp \
           src/server.cpp \
+          src/server/SessionHandler.cpp \
           src/server/StreamingSession.cpp \
           src/server/AuthManager.cpp \
           src/server/ConnectionLimiter.cpp \

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,7 +1,6 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/beast.hpp>
-#include <boost/beast/websocket.hpp>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -16,7 +15,6 @@
 #include "server/SessionHandler.h"
 #include "server/ServerConfig.h"
 #include "server/ConnectionLimiter.h"
-#include "server/ConnectionGuard.h"
 #include "server/TrustedProxyResolver.h"
 #include "server/AuthManager.h"
 #include "auth/ApiAuthConfig.h"

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -13,11 +13,10 @@
 #include <unordered_map>
 #include <sstream>
 #include <cstdlib>
-#include "server/StreamingSession.h"
+#include "server/SessionHandler.h"
 #include "server/ServerConfig.h"
 #include "server/ConnectionLimiter.h"
 #include "server/ConnectionGuard.h"
-#include "server/HandshakeWatchdog.h"
 #include "server/TrustedProxyResolver.h"
 #include "server/AuthManager.h"
 #include "auth/ApiAuthConfig.h"
@@ -32,7 +31,6 @@
 #include "log/Log.h"
 
 using tcp = boost::asio::ip::tcp;
-namespace websocket = boost::beast::websocket;
 namespace ssl = boost::asio::ssl;
 
 namespace 
@@ -353,107 +351,6 @@ HttpRouter buildRouter(const ServerConfig& config,
 
 
 
-void handleSession(tcp::socket socket,
-                   const std::shared_ptr<ConnectionLimiter>& limiter,
-                   const std::string& client_ip,
-                   const ServerConfig& config,
-                   const std::shared_ptr<AuthManager>& auth_manager,
-                   std::shared_ptr<ssl::context> ssl_ctx) {
-    ConnectionGuard guard(limiter, client_ip);
-
-    // The ConnectionGuard slot above is held from here on. Before the
-    // StreamingSession exists (and takes over via its own idle watchdog,
-    // jota-transcriber#68), the TLS handshake and the initial HTTP upgrade
-    // read below have no timeout at all otherwise: a client that opens a
-    // TCP connection and sends nothing (or trickles data arbitrarily
-    // slowly) would hold this slot forever. native_handle() is captured
-    // before any std::move below — it's the same OS-level fd regardless of
-    // which C++ wrapper currently owns it.
-    HandshakeWatchdog handshake_watchdog(socket.native_handle(), config.handshake_timeout_sec);
-
-    try {
-        boost::beast::flat_buffer buffer;
-        http::request_parser<http::string_body> parser;
-        parser.body_limit(config.max_upload_bytes);
-
-        HttpRouter router = buildRouter(config, auth_manager, limiter);
-
-        auto send404 = [](auto& stream, const http::request<http::string_body>& req) {
-            http::response<http::string_body> res{http::status::not_found, req.version()};
-            res.set(http::field::content_type, "application/json");
-            res.body() = R"({"error":{"message":"Not found","type":"not_found"}})";
-            res.prepare_payload();
-            boost::beast::http::write(stream, res);
-        };
-
-        if (ssl_ctx) {
-            ssl::stream<tcp::socket> ssl_stream(std::move(socket), *ssl_ctx);
-            ssl_stream.handshake(ssl::stream_base::server);
-            boost::beast::http::read(ssl_stream, buffer, parser);
-            auto req = parser.release();
-
-            SendFn send = [&](http::response<http::string_body> res) {
-                boost::beast::http::write(ssl_stream, res);
-            };
-            if (router.dispatch(req, send, config, auth_manager)) return;
-
-            if (!websocket::is_upgrade(req)) {
-                send404(ssl_stream, req);
-                return;
-            }
-
-            websocket::stream<ssl::stream<tcp::socket>> ws(std::move(ssl_stream));
-            // From here on, StreamingSession's own idle watchdog (flushLoop)
-            // owns this connection's timeout protection.
-            handshake_watchdog.disarm();
-            auto session = std::make_shared<StreamingSession<websocket::stream<ssl::stream<tcp::socket>>>>(
-                std::move(ws), config.model_path, auth_manager,
-                config.whisper_beam_size, config.whisper_threads,
-                config.whisper_initial_prompt, config.session_timeout_sec,
-                config.whisper_temperature, config.whisper_temperature_inc,
-                config.whisper_no_speech_thold, config.whisper_logprob_thold,
-                config.flush_min_new_audio_ms,
-                config.vad_model_path, config.vad_threshold,
-                config.vad_min_speech_ms, config.vad_min_silence_ms,
-                config.vad_max_speech_s, config.vad_speech_pad_ms,
-                config.vad_samples_overlap);
-            session->run(req);
-        } else {
-            boost::beast::http::read(socket, buffer, parser);
-            auto req = parser.release();
-
-            SendFn send = [&](http::response<http::string_body> res) {
-                boost::beast::http::write(socket, res);
-            };
-            if (router.dispatch(req, send, config, auth_manager)) return;
-
-            if (!websocket::is_upgrade(req)) {
-                send404(socket, req);
-                return;
-            }
-
-            websocket::stream<tcp::socket> ws(std::move(socket));
-            // From here on, StreamingSession's own idle watchdog (flushLoop)
-            // owns this connection's timeout protection.
-            handshake_watchdog.disarm();
-            auto session = std::make_shared<StreamingSession<websocket::stream<tcp::socket>>>(
-                std::move(ws), config.model_path, auth_manager,
-                config.whisper_beam_size, config.whisper_threads,
-                config.whisper_initial_prompt, config.session_timeout_sec,
-                config.whisper_temperature, config.whisper_temperature_inc,
-                config.whisper_no_speech_thold, config.whisper_logprob_thold,
-                config.flush_min_new_audio_ms,
-                config.vad_model_path, config.vad_threshold,
-                config.vad_min_speech_ms, config.vad_min_silence_ms,
-                config.vad_max_speech_s, config.vad_speech_pad_ms,
-                config.vad_samples_overlap);
-            session->run(req);
-        }
-    } catch (std::exception& e) {
-        Log::error("Session exception from " + client_ip + ": " + e.what());
-    }
-}
-
 } // namespace
 
 int main(int argc, char* argv[]) {
@@ -572,6 +469,8 @@ int main(int argc, char* argv[]) {
             stop_trusted_refresh = true;
         });
 
+        HttpRouter router = buildRouter(config, auth_manager, limiter);
+
         while (acceptor.is_open()) {
             tcp::socket socket(ioc);
             boost::system::error_code ec;
@@ -599,13 +498,14 @@ int main(int argc, char* argv[]) {
                       (trusted ? " (trusted proxy)" : ""));
 
             try {
-                session_threads.emplace_back(handleSession,
+                session_threads.emplace_back(SessionHandler::handleSession,
                         std::move(socket),
                         limiter,
                         client_ip,
                         config,
                         auth_manager,
-                        ssl_ctx);
+                        ssl_ctx,
+                        router);
             } catch (const std::exception& e) {
                 limiter->release(client_ip);
                 Log::error("Failed to spawn session thread: " + std::string(e.what()) +

--- a/src/server/SessionHandler.cpp
+++ b/src/server/SessionHandler.cpp
@@ -85,7 +85,7 @@ void handleSession(tcp::socket socket,
         } else {
             boost::beast::http::read(socket, buffer, parser);
             auto req = parser.release();
-            handshake_watchdog.disarm();
+            handshake_watchdog.disarm(); // see TLS branch above (jota-transcriber#81)
 
             SendFn send = [&](http::response<http::string_body> res) {
                 boost::beast::http::write(socket, res);

--- a/src/server/SessionHandler.cpp
+++ b/src/server/SessionHandler.cpp
@@ -53,6 +53,11 @@ void handleSession(tcp::socket socket,
             ssl_stream.handshake(ssl::stream_base::server);
             boost::beast::http::read(ssl_stream, buffer, parser);
             auto req = parser.release();
+            // Full request (headers + body) is in hand — whatever happens
+            // next (a synchronous handler or a WS upgrade) is legitimate
+            // processing, not the "client trickling data slowly" case this
+            // watchdog exists to guard against (jota-transcriber#81).
+            handshake_watchdog.disarm();
 
             SendFn send = [&](http::response<http::string_body> res) {
                 boost::beast::http::write(ssl_stream, res);
@@ -65,7 +70,6 @@ void handleSession(tcp::socket socket,
             }
 
             websocket::stream<ssl::stream<tcp::socket>> ws(std::move(ssl_stream));
-            handshake_watchdog.disarm();
             auto session = std::make_shared<StreamingSession<websocket::stream<ssl::stream<tcp::socket>>>>(
                 std::move(ws), config.model_path, auth_manager,
                 config.whisper_beam_size, config.whisper_threads,
@@ -81,6 +85,7 @@ void handleSession(tcp::socket socket,
         } else {
             boost::beast::http::read(socket, buffer, parser);
             auto req = parser.release();
+            handshake_watchdog.disarm();
 
             SendFn send = [&](http::response<http::string_body> res) {
                 boost::beast::http::write(socket, res);
@@ -93,7 +98,6 @@ void handleSession(tcp::socket socket,
             }
 
             websocket::stream<tcp::socket> ws(std::move(socket));
-            handshake_watchdog.disarm();
             auto session = std::make_shared<StreamingSession<websocket::stream<tcp::socket>>>(
                 std::move(ws), config.model_path, auth_manager,
                 config.whisper_beam_size, config.whisper_threads,

--- a/src/server/SessionHandler.cpp
+++ b/src/server/SessionHandler.cpp
@@ -1,0 +1,115 @@
+#include "server/SessionHandler.h"
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/websocket.hpp>
+#include "server/StreamingSession.h"
+#include "server/ConnectionGuard.h"
+#include "server/ConnectionLimiter.h"
+#include "server/HandshakeWatchdog.h"
+#include "server/AuthManager.h"
+#include "server/ServerConfig.h"
+#include "log/Log.h"
+
+using tcp = boost::asio::ip::tcp;
+namespace websocket = boost::beast::websocket;
+namespace ssl = boost::asio::ssl;
+
+namespace SessionHandler {
+
+void handleSession(tcp::socket socket,
+                   const std::shared_ptr<ConnectionLimiter>& limiter,
+                   const std::string& client_ip,
+                   const ServerConfig& config,
+                   const std::shared_ptr<AuthManager>& auth_manager,
+                   std::shared_ptr<ssl::context> ssl_ctx,
+                   const HttpRouter& router) {
+    ConnectionGuard guard(limiter, client_ip);
+
+    // The ConnectionGuard slot above is held from here on. Before the
+    // StreamingSession exists (and takes over via its own idle watchdog,
+    // jota-transcriber#68), the TLS handshake and the initial HTTP upgrade
+    // read below have no timeout at all otherwise: a client that opens a
+    // TCP connection and sends nothing (or trickles data arbitrarily
+    // slowly) would hold this slot forever. native_handle() is captured
+    // before any std::move below — it's the same OS-level fd regardless of
+    // which C++ wrapper currently owns it.
+    HandshakeWatchdog handshake_watchdog(socket.native_handle(), config.handshake_timeout_sec);
+
+    try {
+        boost::beast::flat_buffer buffer;
+        http::request_parser<http::string_body> parser;
+        parser.body_limit(config.max_upload_bytes);
+
+        auto send404 = [](auto& stream, const http::request<http::string_body>& req) {
+            http::response<http::string_body> res{http::status::not_found, req.version()};
+            res.set(http::field::content_type, "application/json");
+            res.body() = R"({"error":{"message":"Not found","type":"not_found"}})";
+            res.prepare_payload();
+            boost::beast::http::write(stream, res);
+        };
+
+        if (ssl_ctx) {
+            ssl::stream<tcp::socket> ssl_stream(std::move(socket), *ssl_ctx);
+            ssl_stream.handshake(ssl::stream_base::server);
+            boost::beast::http::read(ssl_stream, buffer, parser);
+            auto req = parser.release();
+
+            SendFn send = [&](http::response<http::string_body> res) {
+                boost::beast::http::write(ssl_stream, res);
+            };
+            if (router.dispatch(req, send, config, auth_manager)) return;
+
+            if (!websocket::is_upgrade(req)) {
+                send404(ssl_stream, req);
+                return;
+            }
+
+            websocket::stream<ssl::stream<tcp::socket>> ws(std::move(ssl_stream));
+            handshake_watchdog.disarm();
+            auto session = std::make_shared<StreamingSession<websocket::stream<ssl::stream<tcp::socket>>>>(
+                std::move(ws), config.model_path, auth_manager,
+                config.whisper_beam_size, config.whisper_threads,
+                config.whisper_initial_prompt, config.session_timeout_sec,
+                config.whisper_temperature, config.whisper_temperature_inc,
+                config.whisper_no_speech_thold, config.whisper_logprob_thold,
+                config.flush_min_new_audio_ms,
+                config.vad_model_path, config.vad_threshold,
+                config.vad_min_speech_ms, config.vad_min_silence_ms,
+                config.vad_max_speech_s, config.vad_speech_pad_ms,
+                config.vad_samples_overlap);
+            session->run(req);
+        } else {
+            boost::beast::http::read(socket, buffer, parser);
+            auto req = parser.release();
+
+            SendFn send = [&](http::response<http::string_body> res) {
+                boost::beast::http::write(socket, res);
+            };
+            if (router.dispatch(req, send, config, auth_manager)) return;
+
+            if (!websocket::is_upgrade(req)) {
+                send404(socket, req);
+                return;
+            }
+
+            websocket::stream<tcp::socket> ws(std::move(socket));
+            handshake_watchdog.disarm();
+            auto session = std::make_shared<StreamingSession<websocket::stream<tcp::socket>>>(
+                std::move(ws), config.model_path, auth_manager,
+                config.whisper_beam_size, config.whisper_threads,
+                config.whisper_initial_prompt, config.session_timeout_sec,
+                config.whisper_temperature, config.whisper_temperature_inc,
+                config.whisper_no_speech_thold, config.whisper_logprob_thold,
+                config.flush_min_new_audio_ms,
+                config.vad_model_path, config.vad_threshold,
+                config.vad_min_speech_ms, config.vad_min_silence_ms,
+                config.vad_max_speech_s, config.vad_speech_pad_ms,
+                config.vad_samples_overlap);
+            session->run(req);
+        }
+    } catch (std::exception& e) {
+        Log::error("Session exception from " + client_ip + ": " + e.what());
+    }
+}
+
+} // namespace SessionHandler

--- a/src/server/SessionHandler.h
+++ b/src/server/SessionHandler.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl.hpp>
+#include <memory>
+#include <string>
+#include "server/HttpRouter.h"
+
+class ConnectionLimiter;
+
+namespace SessionHandler {
+    // Reads one HTTP request from `socket` and either dispatches it to a
+    // matching route in `router` (health/ready/metrics/transcribe — all
+    // synchronous) or, if it's a WebSocket upgrade, hands the connection
+    // off to a long-lived StreamingSession. `router` is built once by the
+    // caller and shared read-only across connections. Catches and logs all
+    // exceptions; never throws.
+    void handleSession(boost::asio::ip::tcp::socket socket,
+                       const std::shared_ptr<ConnectionLimiter>& limiter,
+                       const std::string& client_ip,
+                       const ServerConfig& config,
+                       const std::shared_ptr<AuthManager>& auth_manager,
+                       std::shared_ptr<boost::asio::ssl::context> ssl_ctx,
+                       const HttpRouter& router);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(unit_tests
     unit/test_handle_transcribe.cpp
     unit/test_socket_util.cpp
     unit/test_handshake_watchdog.cpp
+    unit/test_session_handler.cpp
     # Fuentes del servidor que no tienen dependencias de Boost/OpenSSL
     ${CMAKE_SOURCE_DIR}/src/audio/AudioDecoder.cpp
     ${CMAKE_SOURCE_DIR}/src/server/ConnectionLimiter.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(unit_tests
     ${CMAKE_SOURCE_DIR}/src/server/AuthManager.cpp
     ${CMAKE_SOURCE_DIR}/src/server/MultipartParser.cpp
     ${CMAKE_SOURCE_DIR}/src/server/HttpRouter.cpp
+    ${CMAKE_SOURCE_DIR}/src/server/SessionHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/AuthCache.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/ApiAuthClient.cpp
     ${CMAKE_SOURCE_DIR}/src/server/handlers/HandleTranscribe.cpp

--- a/tests/unit/test_session_handler.cpp
+++ b/tests/unit/test_session_handler.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
+#include <boost/beast/websocket.hpp>
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include "server/SessionHandler.h"
@@ -14,6 +15,7 @@
 
 namespace beast = boost::beast;
 namespace http = beast::http;
+namespace websocket = boost::beast::websocket;
 namespace net = boost::asio;
 using tcp = boost::asio::ip::tcp;
 
@@ -97,4 +99,61 @@ TEST(SessionHandler, SlowHandlerSurvivesHandshakeTimeout) {
     EXPECT_EQ(res.body(), "done");
     EXPECT_GE(elapsed, handler_delay)
         << "response arrived before the handler's artificial delay finished";
+}
+
+// jota-transcriber#81 follow-up: the refactor made handleSession()'s
+// WebSocket-upgrade branch reachable from a test for the first time, but
+// only the non-upgrading HTTP path got one (above). This exercises the
+// is_upgrade branch itself: a real WS handshake through handleSession(),
+// followed by a wait past handshake_timeout_sec with no application traffic
+// (mirroring a client that's slow to send its first "config" message) to
+// prove the watchdog stays disarmed after handoff into StreamingSession —
+// not just for the synchronous-HTTP case.
+TEST(SessionHandler, WebSocketUpgradeSurvivesHandshakeTimeoutAfterHandoff) {
+    net::io_context ioc;
+    tcp::acceptor acceptor(ioc, tcp::endpoint(net::ip::make_address("127.0.0.1"), 0));
+    uint16_t port = acceptor.local_endpoint().port();
+
+    ServerConfig config;
+    config.handshake_timeout_sec = 1;                          // watchdog deadline
+    const auto post_upgrade_idle = std::chrono::milliseconds(1500); // exceeds it
+
+    HttpRouter router; // no HTTP routes registered — this request must fall through to WS upgrade
+    auto limiter = std::make_shared<ConnectionLimiter>(8, 2);
+    ApiAuthConfig auth_cfg; // handleSession() requires a non-null AuthManager;
+                             // no "config" message is ever sent in this test,
+                             // so its enabled/disabled state is irrelevant
+    auto auth_manager = std::make_shared<AuthManager>(auth_cfg);
+
+    std::thread server_thread([&]() {
+        tcp::socket socket(ioc);
+        acceptor.accept(socket);
+        SessionHandler::handleSession(std::move(socket), limiter, "127.0.0.1",
+                                       config, auth_manager, /*ssl_ctx=*/nullptr, router);
+    });
+
+    tcp::resolver resolver(ioc);
+    auto const results = resolver.resolve("127.0.0.1", std::to_string(port));
+    websocket::stream<tcp::socket> client_ws(ioc);
+    net::connect(client_ws.next_layer(), results.begin(), results.end());
+
+    boost::system::error_code ec;
+    client_ws.handshake("127.0.0.1", "/", ec);
+    ASSERT_FALSE(ec) << "WS handshake through handleSession() failed: " << ec.message();
+
+    // No "config", no audio — just sit on the open connection past the
+    // watchdog's deadline. If handleSession() ever regressed to disarming
+    // only after router.dispatch() (the pre-#81 behavior) or re-armed the
+    // watchdog anywhere on this branch, the fd would be force-shut here and
+    // the close handshake below would fail with a reset/broken-pipe error.
+    std::this_thread::sleep_for(post_upgrade_idle);
+
+    client_ws.close(websocket::close_code::normal, ec);
+
+    server_thread.join();
+
+    EXPECT_FALSE(ec) << "clean WS close failed (ec=" << ec.message()
+                      << ") — the handshake watchdog likely force-closed the "
+                         "socket after upgrade, before the idle client could "
+                         "send anything";
 }

--- a/tests/unit/test_session_handler.cpp
+++ b/tests/unit/test_session_handler.cpp
@@ -56,7 +56,9 @@ TEST(SessionHandler, SlowHandlerSurvivesHandshakeTimeout) {
 
     HttpRouter router = buildSlowRouter(handler_delay);
     auto limiter = std::make_shared<ConnectionLimiter>(8, 2);
-    ApiAuthConfig auth_cfg; // no token/API → auth disabled
+    ApiAuthConfig auth_cfg; // handleSession() requires a non-null AuthManager;
+                             // the /slow route never consults it, so its
+                             // enabled/disabled state is irrelevant here
     auto auth_manager = std::make_shared<AuthManager>(auth_cfg);
 
     std::thread server_thread([&]() {

--- a/tests/unit/test_session_handler.cpp
+++ b/tests/unit/test_session_handler.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include "server/SessionHandler.h"
+#include "server/HttpRouter.h"
+#include "server/ConnectionLimiter.h"
+#include "server/AuthManager.h"
+#include "auth/ApiAuthConfig.h"
+#include "server/ServerConfig.h"
+#include <chrono>
+#include <thread>
+
+namespace beast = boost::beast;
+namespace http = beast::http;
+namespace net = boost::asio;
+using tcp = boost::asio::ip::tcp;
+
+namespace {
+
+// A router with a single POST /slow route whose handler sleeps past the
+// configured handshake timeout before responding — standing in for a
+// legitimately slow synchronous HTTP handler (e.g. a long whisper
+// transcription in HandleTranscribe).
+HttpRouter buildSlowRouter(std::chrono::milliseconds handler_delay) {
+    HttpRouter router;
+    router.add(http::verb::post, "/slow",
+        [handler_delay](const http::request<http::string_body>& req, SendFn send,
+                        const ServerConfig&, const std::shared_ptr<AuthManager>&) {
+            std::this_thread::sleep_for(handler_delay);
+            http::response<http::string_body> res{http::status::ok, req.version()};
+            res.set(http::field::content_type, "text/plain");
+            res.body() = "done";
+            res.prepare_payload();
+            send(res);
+        });
+    return router;
+}
+
+} // namespace
+
+// jota-transcriber#81: HandshakeWatchdog is meant to bound only the TLS
+// handshake + initial HTTP read (a client trickling data slowly), but it
+// stayed armed through synchronous handler execution too. Any request whose
+// handler takes longer than --handshake-timeout-sec got its socket force-
+// shut mid-response, and the client received nothing.
+TEST(SessionHandler, SlowHandlerSurvivesHandshakeTimeout) {
+    net::io_context ioc;
+    tcp::acceptor acceptor(ioc, tcp::endpoint(net::ip::make_address("127.0.0.1"), 0));
+    uint16_t port = acceptor.local_endpoint().port();
+
+    ServerConfig config;
+    config.handshake_timeout_sec = 1;                       // watchdog deadline
+    const auto handler_delay = std::chrono::milliseconds(2000); // exceeds it
+
+    HttpRouter router = buildSlowRouter(handler_delay);
+    auto limiter = std::make_shared<ConnectionLimiter>(8, 2);
+    ApiAuthConfig auth_cfg; // no token/API → auth disabled
+    auto auth_manager = std::make_shared<AuthManager>(auth_cfg);
+
+    std::thread server_thread([&]() {
+        tcp::socket socket(ioc);
+        acceptor.accept(socket);
+        SessionHandler::handleSession(std::move(socket), limiter, "127.0.0.1",
+                                       config, auth_manager, /*ssl_ctx=*/nullptr, router);
+    });
+
+    tcp::resolver resolver(ioc);
+    auto const results = resolver.resolve("127.0.0.1", std::to_string(port));
+    tcp::socket client_socket(ioc);
+    net::connect(client_socket, results.begin(), results.end());
+
+    http::request<http::string_body> req{http::verb::post, "/slow", 11};
+    req.set(http::field::host, "127.0.0.1");
+    req.set(http::field::content_type, "text/plain");
+    req.body() = "x";
+    req.prepare_payload();
+
+    auto start = std::chrono::steady_clock::now();
+    http::write(client_socket, req);
+
+    beast::flat_buffer buffer;
+    http::response<http::string_body> res;
+    boost::system::error_code ec;
+    http::read(client_socket, buffer, res, ec);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    server_thread.join();
+
+    ASSERT_FALSE(ec) << "client never received a response (ec=" << ec.message()
+                      << ") — the handshake watchdog likely force-closed the "
+                         "socket while the handler was still running";
+    EXPECT_EQ(res.result(), http::status::ok);
+    EXPECT_EQ(res.body(), "done");
+    EXPECT_GE(elapsed, handler_delay)
+        << "response arrived before the handler's artificial delay finished";
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what this pull request does.

Looking at the changes:

1. **CMakeLists.txt** - Added `src/server/SessionHandler.cpp` to the build
2. **Dockerfile** - Added `src/server/SessionHandler.cpp` to the touch list
3. **src/server.cpp** - 
   - Removed the `handleSession` function (moved to SessionHandler.cpp)
   - Changed includes to use SessionHandler.h instead of directly including StreamingSession.h, ConnectionGuard.h, HandshakeWatchdog.h
   - Now builds the HttpRouter once and passes it to SessionHandler::handleSession
   - Changed from calling local `handleSession` function to calling `SessionHandler::handleSession`

4. **src/server/SessionHandler.cpp** - New file containing the session handling logic
   - The key change is in the handshake watchdog timing:
     - Before: `handshake_watchdog.disarm()` was only called after WebSocket upgrade
     - After: `handshake_watchdog.disarm()` is called right after reading the full HTTP request (both TLS and non-TLS branches)
   - This ensures that slow synchronous HTTP handlers (like long transcription operations) don't get killed by the handshake timeout watchdog

5. **src/server/SessionHandler.h** - New header file declaring the SessionHandler namespace

6. **tests/CMakeLists.txt** - Added test_session_handler.cpp
7. **tests/unit/test_session_handler.cpp** - New test file with two tests:
   - `SlowHandlerSurvivesHandshakeTimeout`: Tests that a slow HTTP handler (that takes longer than handshake_timeout_sec) can complete successfully
   - `WebSocketUpgradeSurvivesHandshakeTimeoutAfterHandoff`: Tests that WebSocket upgrade path also works correctly

The key fix is described in the PR title: "HandshakeWatchdog kills long-running HTTP requests, not just idle handshakes"


The root cause was that the watchdog timer remained active during synchronous handler execution, causing connections to drop when operations exceeded the timeout threshold. By disarming the watchdog immediately after reading the complete HTTP request, slow handlers can now run to completion without premature termination.
</think>

## Summary

This pull request fixes a bug where the `HandshakeWatchdog` was incorrectly terminating long-running synchronous HTTP requests (such as transcription operations) instead of only protecting against idle connections during the initial handshake phase.

### Key Changes

1. **Refactored session handling into a dedicated class**: The `handleSession` function was moved from `server.cpp` into a new `SessionHandler` class with its own source and header files.

2. **Fixed handshake watchdog timing**: The critical fix is in `SessionHandler.cpp` - the `handshake_watchdog.disarm()` call now executes immediately after the full HTTP request is read (both TLS and non-TLS branches), rather than only after the WebSocket upgrade. This ensures that legitimate synchronous HTTP handlers that take longer than `handshake-timeout-sec` are allowed to complete without being killed.

3. **Added unit tests**: Two new tests verify the fix:
   - `SlowHandlerSurvivesHandshakeTimeout`: Confirms that a slow synchronous HTTP handler (exceeding the handshake timeout) completes successfully
   - `WebSocketUpgradeSurvivesHandshakeTimeoutAfterHandoff`: Confirms the WebSocket upgrade path also works correctly after the refactor

### Issue Reference

This fix addresses issue #81 where any HTTP request handler taking longer than the configured handshake timeout would have its socket force-closed mid-response, resulting in clients receiving no response.
<!-- kody-pr-summary:end -->